### PR TITLE
Take care of xx/yy; charset mimetypes

### DIFF
--- a/src/dist/perf-cascade.js
+++ b/src/dist/perf-cascade.js
@@ -340,11 +340,16 @@ exports.default = HarTransformer;
  */
 function mimeToRequestType(mimeType) {
     var types = mimeType.split("/");
+    var part2 = types[1];
+    // take care of text/css; charset=UTF-8 etc
+    if (part2 !== undefined) {
+        part2 = part2.indexOf(";") > -1 ? part2.split(";")[0] : part2;
+    }
     switch (types[0]) {
         case "image": return "image";
         case "font": return "font";
     }
-    switch (types[1]) {
+    switch (part2) {
         case "svg+xml": return "svg";
         case "xml":
         case "html": return "html";

--- a/src/ts/transformers/styling-converters.ts
+++ b/src/ts/transformers/styling-converters.ts
@@ -1,14 +1,20 @@
 /**
  * Convert a MIME type into it's WPT style request type (font, script etc)
- * @param {string} mimeType 
+ * @param {string} mimeType
  */
 export function mimeToRequestType(mimeType: string) {
+
   let types = mimeType.split("/");
+  let part2 = types[1];
+  // take care of text/css; charset=UTF-8 etc
+  if (part2 !== undefined) {
+    part2 = part2.indexOf(";") > -1 ? part2.split(";")[0]: part2;
+  }
   switch (types[0]) {
     case "image": return "image"
     case "font": return "font"
   }
-  switch (types[1]) {
+  switch (part2) {
     case "svg+xml": return "svg"
     case "xml":
     case "html": return "html"
@@ -31,7 +37,7 @@ export function mimeToRequestType(mimeType: string) {
 
 /**
  * Convert a MIME type into a CSS class
- * @param {string} mimeType 
+ * @param {string} mimeType
  */
 export function mimeToCssClass(mimeType: string) {
   return "block-" + mimeToRequestType(mimeType)


### PR DESCRIPTION
The current version didn't handled mime-types with charset in the header. Closes #16
