### PR TITLE
Pickup metrics also from the request

### DIFF
--- a/src/ts/waterfall/svg-details-overlay.ts
+++ b/src/ts/waterfall/svg-details-overlay.ts
@@ -90,7 +90,7 @@ function getKeys(requestID: number, block: TimeBlock) {
 
   /** get experimental feature */
   let getExp = (name: string): string => {
-    return entry[name] || entry["_" + name] || ""
+    return entry[name] || entry["_" + name] || entry.request[name] || entry.request["_" + name] || ""
   }
 
   let getExpNotNull = (name: string): string => {
@@ -125,7 +125,7 @@ function getKeys(requestID: number, block: TimeBlock) {
       "Error/Status Code": entry.response.status + " " + entry.response.statusText,
       "Server IPAddress": entry.serverIPAddress,
       "Connection": entry.connection,
-      "Browser Priority": getExp("priority"),
+      "Browser Priority": getExp("priority") || getExp("initialPriority"),
       "Initiator (Loaded by)": getExp("initiator"),
       "Initiator Line": getExp("initiator_line"),
       "Host": getRequestHeader("Host"),


### PR DESCRIPTION
Added so also pickup info from the request object, we use that in Browsertime becasue it's cleaner to have the browser prio from Chrome where it belongs. We don't have any more metrics right now in the request object but I hope it feels ok still to add it there.
