### PR TITLE
Guard against undefined mime types

### DIFF
--- a/src/ts/transformers/styling-converters.ts
+++ b/src/ts/transformers/styling-converters.ts
@@ -3,7 +3,8 @@
  * @param {string} mimeType
  */
 export function mimeToRequestType(mimeType: string) {
-
+  if (mimeType === undefined)
+    return "other"
   let types = mimeType.split("/")
   let part2 = types[1]
   // take care of text/css; charset=UTF-8 etc


### PR DESCRIPTION
Started to testing the wild and we HAR files that have an undefined
content type. This fixes the problem but maybe we should classify them
as undefined instead of others ...

Ping @beenanner and https://github.com/sitespeedio/sitespeed.io/issues/1030
