### PR TITLE
Use HAR timings in timing tab and legend

### DIFF
--- a/src/css-raw/perf-cascade.css
+++ b/src/css-raw/perf-cascade.css
@@ -119,13 +119,13 @@ svg.water-fall-chart {width:100%; overflow: visible;}
 .info-overlay-holder .no-colour,
 .info-overlay-holder .serverrtt,
 .info-overlay-holder .allcombined,
-.info-overlay-holder .load {border-right: solid 5px transparent; padding-right: 5px;}
-.info-overlay-holder .blocked {border-right: solid 5px #ccc; padding-right: 5px;}
-.info-overlay-holder .dns {border-right: solid 5px #1f7c83; padding-right: 5px;}
 .info-overlay-holder .connect {border-right: solid 5px #e58226; padding-right: 5px;}
-.info-overlay-holder .tlsssl {border-right: solid 5px #c141cd; padding-right: 5px;}
-.info-overlay-holder .ttfb {border-right: solid 5px #1fe11f; padding-right: 5px;}
-.info-overlay-holder .download {border-right: solid 5px #1977dd; padding-right: 5px;}
+.info-overlay-holder .blocked {border-right: solid 5px #ccc; padding-right: 5px;}
+.info-overlay-holder .ssl {border-right: solid 5px #c141cd; padding-right: 5px;}
+.info-overlay-holder .send {border-right: solid 5px #1fe110; padding-right: 5px;}
+.info-overlay-holder .wait {border-right: solid 5px #1fe11f; padding-right: 5px;}
+.info-overlay-holder .receive {border-right: solid 5px #1977dd; padding-right: 5px;}
+.info-overlay-holder .dns {border-right: solid 5px #1f7c83; padding-right: 5px;}
 
 /* Info overlay HTML - types */
 .type-css {background: #406B29;}/*a6d18f - 40%*/
@@ -182,11 +182,10 @@ svg.water-fall-chart {width:100%; overflow: visible;}
 .resource-legend li {margin: 0 1em 0 0; padding: 0; white-space: nowrap; display: inline-block;}
 .resource-legend li:before {content:''; width: 1em; height: 1em; margin: 0 0.5em 0 0; vertical-align: text-top; display: inline-block; }
 
-.resource-legend .legend-stalled:before { background: #cdcdcd;}
-.resource-legend .legend-redirect:before { background: #ffff60;}
-.resource-legend .legend-app-cache:before { background: #1f831f; }
-.resource-legend .legend-dns-lookup:before { background: #1f7c83; }
-.resource-legend .legend-tcp:before { background: #e58226; }
-.resource-legend .legend-tls:before { background: #c141cd; }
-.resource-legend .legend-ttfb:before { background: #1fe11f; }
-.resource-legend .legend-download:before { background: #1977dd; }
+.resource-legend .legend-blocked:before { background: #ccc;}
+.resource-legend .legend-dns:before { background: #1f7c83;}
+.resource-legend .legend-connect:before { background: #e58226; }
+.resource-legend .legend-ssl:before { background: #c141cd; }
+.resource-legend .legend-send:before { background: #1fe110; }
+.resource-legend .legend-wait:before { background: #c141cd; }
+.resource-legend .legend-receive:before { background: #1977dd; }

--- a/src/ts/legend/legend.ts
+++ b/src/ts/legend/legend.ts
@@ -8,7 +8,7 @@ export function makeLegend(): HTMLUListElement {
   ulNode.innerHTML = `
         <li class="legend-blocked">Blocked</li>
         <li class="legend-dns">DNS</li>
-        <li class="legend-ssl">SSL</li>
+        <li class="legend-ssl">SSL (TLS)</li>
         <li class="legend-connect">Connect</li>
         <li class="legend-send">Send</li>
         <li class="legend-wait">Wait</li>

--- a/src/ts/legend/legend.ts
+++ b/src/ts/legend/legend.ts
@@ -6,13 +6,12 @@ export function makeLegend(): HTMLUListElement {
   ulNode.className = "resource-legend"
 
   ulNode.innerHTML = `
-        <li class="legend-stalled">Stalled/Blocking</li>
-        <li class="legend-redirect">Redirect</li>
-        <li class="legend-app-cache">App Cache</li>
-        <li class="legend-dns-lookup">DNS Lookup</li>
-        <li class="legend-tcp">Initial Connection (TCP)</li>
-        <li class="legend-tls">TLS/SSL Negotiation</li>
-        <li class="legend-ttfb">Time to First Byte</li>
-        <li class="legend-download">Content Download</li>`
+        <li class="legend-blocked">Blocked</li>
+        <li class="legend-dns">DNS</li>
+        <li class="legend-ssl">SSL</li>
+        <li class="legend-connect">Connect</li>
+        <li class="legend-send">Send</li>
+        <li class="legend-wait">Wait</li>
+        <li class="legend-receive">Receive</li>`
   return ulNode
 }

--- a/src/ts/waterfall/details-overlay/extract-details-keys.ts
+++ b/src/ts/waterfall/details-overlay/extract-details-keys.ts
@@ -61,6 +61,10 @@ export function getKeys(requestID: number, block: TimeBlock) {
     return entry[name] || entry["_" + name] || entry.request[name] || entry.request["_" + name] || ""
   }
 
+  let getExpTimings = (name: string): string => {
+    return entry.timings[name] || ""
+  }
+
   let getExpNotNull = (name: string): string => {
     let resp = getExp(name)
     return resp !== "0" ? resp : ""
@@ -69,20 +73,6 @@ export function getKeys(requestID: number, block: TimeBlock) {
   let getExpAsByte = (name: string): string => {
     let resp = parseInt(getExp(name), 10)
     return (isNaN(resp) || resp <= 0) ? "" : formatBytes(resp)
-  }
-
-  let getExpTimeRange = (name: string): string => {
-    let ms = getExp(name + "_ms").toString()
-    let start = getExp(name + "_start")
-    let end = getExp(name + "_end")
-    let resp = []
-    if (ms && ms !== "-1") {
-      resp.push(`${ms} ms`)
-    }
-    if (start && end && start < end) {
-      resp.push(`(${start} ms - ${end} ms)`)
-    }
-    return resp.join(" ")
   }
 
   return {
@@ -114,14 +104,13 @@ export function getKeys(requestID: number, block: TimeBlock) {
       "Image Save": getExpAsByte("image_save"),
     },
     "timings": {
-      "Server RTT": getExpTimeRange("server_rtt"),
-      "Total": getExpTimeRange("all"),
-      "DNS": getExpTimeRange("dns"),
-      "Connect": getExpTimeRange("connect"),
-      "TLS/SSL": getExpTimeRange("ssl"),
-      "Load": getExpTimeRange("load"),
-      "TTFB": getExpTimeRange("ttfb"),
-      "Download": getExpTimeRange("download"),
+      "Blocked": getExpTimings("blocked"),
+      "Connect": getExpTimings("connect"),
+      "DNS": getExpTimings("dns"),
+      "Receive": getExpTimings("receive"),
+      "Send": getExpTimings("send"),
+      "SSL": getExpTimings("ssl"),
+      "Wait": getExpTimings("wait"),
     },
     "request": {
       "Method": entry.request.method,


### PR DESCRIPTION
The timing tab was generated by timings specific for WebPageTest HAR files
instead of using HAR generic timings https://github.com/micmro/PerfCascade/issues/69 and the legend also used WebPageTest (and resource timing) timing names https://github.com/micmro/PerfCascade/issues/68

Now we use the default names in the HAR.