### PR TITLE
Shorten both http and https url when formatting.

### DIFF
--- a/src/ts/helpers/misc.ts
+++ b/src/ts/helpers/misc.ts
@@ -35,7 +35,7 @@ export function contains<T>(arr: Array<T>, item: T): boolean {
  */
 export function ressourceUrlFormater(url: string, maxLength: number): string {
   if (url.length < maxLength) {
-    return url.replace(/http[s]\:\/\//, "")
+    return url.replace(/https?:\/\//, "")
   }
 
   let matches = parseUrl(url)


### PR DESCRIPTION
Previously only https urls that were short enough had the protocol stripped when formatting a url for display.