### PR TITLE
Don't show content types for errors/redirects, use warning/redirect symbol instead

### DIFF
--- a/src/ts/waterfall/row/svg-indicators.ts
+++ b/src/ts/waterfall/row/svg-indicators.ts
@@ -30,17 +30,13 @@ export function getMimeTypeIcon(block: TimeBlock): Icon {
   if (!!entry.response.redirectURL) {
     const url = encodeURI(entry.response.redirectURL.split("?")[0] || "")
     return makeIcon("err3xx", `${entry.response.status} response status: Redirect to ${url}...`)
-  }
-
-  else if (heuristics.isInStatusCodeRange(entry, 400, 499)) {
+  } else if (heuristics.isInStatusCodeRange(entry, 400, 499)) {
     return makeIcon("err4xx", `${entry.response.status} response status: ${entry.response.statusText}`)
-  }
-
-  else if (heuristics.isInStatusCodeRange(entry, 500, 599)) {
+  } else if (heuristics.isInStatusCodeRange(entry, 500, 599)) {
     return makeIcon("err5xx", `${entry.response.status} response status: ${entry.response.statusText}`)
+  } else {
+    return makeIcon(block.requestType, block.requestType)
   }
-
-  else return makeIcon(block.requestType, block.requestType)
 }
   /**
    * Scan the request for errors or portential issues and highlight them


### PR DESCRIPTION
In the current version if we get a 40x, 50x or 3xx we check for content type and show that. I don't think the content type is relevant in those cases, it's better to show the redirect symbol or warning sign.

We should rename "getMimeTypeIcon" now when we not only get mime types. any suggestions?

#85