### PR TITLE
Allow caller of readFile to handle errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ If set a legend explaining the waterfall colours is rendered in the `legendHolde
 By loading `/perf-cascade-file-reader.min.js` as in [this example](https://github.com/micmro/PerfCascade/blob/master/src/index.html#L73-L80) you can use `perfCascadeFileReader.readFile` to read a gzip and convert it to a JSON HAR object.
 
 ```
-perfCascadeFileReader.readFile(fileFromTheFileInput, fileName, function(data){
-  if(!data){
+perfCascadeFileReader.readFile(fileFromTheFileInput, fileName, function(error, data){
+  if(error){
     // handle error
-    console.error("Can't read file")
+    console.error(error)
   }else{
     // handle success
     renderPerfCascadeChart(data)

--- a/src/index.html
+++ b/src/index.html
@@ -77,7 +77,7 @@
           // Just needed for gzipped *.zhar files, you can use the standard FileReader api for normal .har files
           perfCascadeFileReader.readFile(files[0], evt.target.value, function(error, data){
             if(error){
-              console.error(e)
+              console.error(error)
             }else{
               renderPerfCascadeChart(data)
             }

--- a/src/index.html
+++ b/src/index.html
@@ -75,9 +75,9 @@
           }
 
           // Just needed for gzipped *.zhar files, you can use the standard FileReader api for normal .har files
-          perfCascadeFileReader.readFile(files[0], evt.target.value, function(data){
-            if(!data){
-              console.error("Can't read file")
+          perfCascadeFileReader.readFile(files[0], evt.target.value, function(error, data){
+            if(error){
+              console.error(e)
             }else{
               renderPerfCascadeChart(data)
             }

--- a/src/ts/file-reader.ts
+++ b/src/ts/file-reader.ts
@@ -4,21 +4,18 @@ declare var zip: any;
 zip.useWebWorkers = false
 
 /** handle client side file upload */
-export function readFile(file: File, fileName: string, onDone: Function) {
+export function readFile(file: File, fileName: string, callback: Function) {
   if (!file) {
-    alert("Failed to load HAR file")
-    onDone()
+    callback(new Error("Failed to load HAR file"))
   }
 
   function parseJson(rawData) {
-    let harData
     try {
-      harData = JSON.parse(rawData)
+      let harData = JSON.parse(rawData)
+      callback(null, harData.log)
     } catch (e) {
-      alert("File does not seem to be a valid HAR file")
-      return undefined
+      callback(e)
     }
-    onDone(harData.log)
   }
 
   /** start reading the file */

--- a/src/ts/file-reader.ts
+++ b/src/ts/file-reader.ts
@@ -6,7 +6,7 @@ zip.useWebWorkers = false
 /** handle client side file upload */
 export function readFile(file: File, fileName: string, callback: Function) {
   if (!file) {
-    callback(new Error("Failed to load HAR file"))
+    return callback(new Error("Failed to load HAR file"))
   }
 
   function parseJson(rawData) {


### PR DESCRIPTION
Instead of always alert()-ing errors, have caller decide by using a (error, data) callback pattern.
NOTE: This is a change in the public api.