### PR TITLE
Follow redirects for check if document is https.

### DIFF
--- a/src/ts/helpers/heuristics.ts
+++ b/src/ts/helpers/heuristics.ts
@@ -1,5 +1,5 @@
 import {Entry} from "../typing/har";
-import {WaterfallEntry} from "../typing/waterfall";
+import {WaterfallData, WaterfallEntry} from "../typing/waterfall";
 import {getHeader, hasHeader} from "./har";
 import * as misc from "./misc";
 
@@ -73,4 +73,14 @@ export function hasCompressionIssue(entry: WaterfallEntry) {
 
 export function isSecure(entry: WaterfallEntry) {
   return entry.name.indexOf("https://") === 0;
+}
+
+/**
+ * Check if the document (disregarding any initial http->https redirects) is loaded over a secure connection.
+ * @param data the waterfall data.
+ * @returns {boolean}
+ */
+export function documentIsSecure(data: WaterfallData) {
+  const rootDocument = data.entries.filter((e) => !e.rawResource.response.redirectURL)[0];
+  return isSecure(rootDocument);
 }

--- a/src/ts/helpers/heuristics.ts
+++ b/src/ts/helpers/heuristics.ts
@@ -77,7 +77,7 @@ export function isSecure(entry: WaterfallEntry) {
 
 /**
  * Check if the document (disregarding any initial http->https redirects) is loaded over a secure connection.
- * @param data the waterfall data.
+ * @param {WaterfallData} data -  the waterfall data.
  * @returns {boolean}
  */
 export function documentIsSecure(data: WaterfallData) {

--- a/src/ts/waterfall/svg-chart.ts
+++ b/src/ts/waterfall/svg-chart.ts
@@ -1,3 +1,4 @@
+import {documentIsSecure} from "../helpers/heuristics";
 import * as svg from "../helpers/svg";
 import {requestTypeToCssClass} from "../transformers/styling-converters";
 import {Context} from "../typing/context";
@@ -40,7 +41,7 @@ function createContext(data: WaterfallData, options: ChartOptions,
                        entriesToShow: WaterfallEntry[], overlayHolder: SVGGElement): Context {
   const unit = data.durationMs / 100;
   const diagramHeight = (entriesToShow.length + 1) * options.rowHeight;
-  const docIsSsl = (data.entries[0].name.indexOf("https://") === 0);
+  const docIsSsl = documentIsSecure(data);
 
   let context = {
     diagramHeight,


### PR DESCRIPTION
This gives more useful information for pages that does an initial http->https redirect. Previously the page would be considered http, thus not warning about non-https assets on the page.