### PR TITLE
Show two waterfalls on example page.

### DIFF
--- a/src/css-raw/page.css
+++ b/src/css-raw/page.css
@@ -40,4 +40,4 @@ textarea {
 }
 
 
-#page-selector {display: none; clear: both; margin: 1em 0;}
+.page-selector {display: none; clear: both; margin: 1em 0;}

--- a/src/css-raw/perf-cascade.css
+++ b/src/css-raw/perf-cascade.css
@@ -1,7 +1,7 @@
 
 * {box-sizing: border-box;}
 
-#output {margin: 2em 0; font-size: 12px; line-height: 1em;}
+.output {margin: 2em 0; font-size: 12px; line-height: 1em;}
 
 .water-fall-holder {fill:#ccc;}
 

--- a/src/index.html
+++ b/src/index.html
@@ -14,11 +14,15 @@
 
 <body>
 
-  <input type="file" id="fileinput" />
-
-  <select id="page-selector"></select>
   <div id="legendHolder"></div>
-  <div id="output"></div>
+
+  <input type="file" id="fileinput" />
+  <select id="page-selector" class="page-selector"></select>
+  <div id="output" class="output"></div>
+
+  <input type="file" id="fileinput2" />
+  <select id="page-selector2" class="page-selector"></select>
+  <div id="output2" class="output"></div>
 
   <!-- import PerfCascade JS /-->
   <script src="dist/perf-cascade.js"></script>
@@ -35,62 +39,60 @@
         /** holder DOM element to render PerfCascade into */
         var outputHolderEl = document.getElementById("output")
         var pageSelectorEl = document.getElementById("page-selector")
+        var outputHolder2El = document.getElementById("output2")
+        var pageSelector2El = document.getElementById("page-selector2")
         var legendHolderEl = document.getElementById("legendHolder")
 
+        function setup(options, fileinputId, outputHolder) {
+          /**
+           * This is where the magic happens
+           */
+          function renderPerfCascadeChart(logData) {
+              /** remove all children of `outputHolderEl`,
+               * so you can upload new HAR files and get a new SVG  */
+              while (outputHolder.childNodes.length > 0) {
+                  outputHolder.removeChild(outputHolder.childNodes[0])
+              }
 
-        /**
-         * This is where the magic happens
-         */
-        function renderPerfCascadeChart(logData) {
-          /** remove all children of `outputHolderEl`,
-           * so you can upload new HAR files and get a new SVG  */
-          while (outputHolderEl.childNodes.length > 0) {
-            outputHolderEl.removeChild(outputHolderEl.childNodes[0])
+              /** pass HAR and options to `newPerfCascadeHar` to generate the SVG element*/
+              var perfCascadeSvg =  perfCascade.fromHar(logData, options)
+
+              /** append SVG to page - that's it */
+              outputHolder.appendChild(perfCascadeSvg)
           }
 
-          /** options for PerfCascade (use defaults for the rest) */
-          var options = {
-            pageSelector: pageSelectorEl,
-            legendHolder: legendHolderEl //passes holder for Legend - if not set no legend is shown
+
+          /** handle client side file upload via file-reader */
+          function onFileSubmit(evt) {
+              var files = evt.target.files
+              if (!files) {
+                  alert("Failed to load HAR file")
+                  return
+              }
+
+              // Just needed for gzipped *.zhar files, you can use the standard FileReader api for normal .har files
+              perfCascadeFileReader.readFile(files[0], evt.target.value, function(error, data){
+                  if(error){
+                      console.error(error)
+                  }else{
+                      renderPerfCascadeChart(data)
+                  }
+              })
           }
 
-          /** pass HAR and options to `newPerfCascadeHar` to generate the SVG element*/
-          var perfCascadeSvg =  perfCascade.fromHar(logData, options)
+          if (window["fetch"]) {/** load an initial HAR when opening the page */
+          //Source: http://www.webpagetest.org/result/151226_X7_b43d35e592fab70e0ba012fe11a41020/
+          // window["fetch"]("test-data/www.bbc.co.uk.160529_8V_7R3.har")
+          // window["fetch"]("test-data/www.bbc.com.har")
+          window["fetch"]("test-data/github.com.MODIFIED.151226_X7_b43d35e592fab70e0ba012fe11a41020.har")
+            .then(f => f.json().then(j => renderPerfCascadeChart(j.log)))}
 
-          /** append SVG to page - that's it */
-          outputHolderEl.appendChild(perfCascadeSvg)
-        }
+          /** hook up file input events */
+          document.getElementById(fileinputId).addEventListener("change", onFileSubmit, false)
+      }
 
-
-        /** handle client side file upload via file-reader */
-        function onFileSubmit(evt) {
-          var files = evt.target.files
-          if (!files) {
-            alert("Failed to load HAR file")
-            return
-          }
-
-          // Just needed for gzipped *.zhar files, you can use the standard FileReader api for normal .har files
-          perfCascadeFileReader.readFile(files[0], evt.target.value, function(error, data){
-            if(error){
-              console.error(error)
-            }else{
-              renderPerfCascadeChart(data)
-            }
-          })
-        }
-
-          if (window["fetch"]) {
-              /** load an initial HAR when opening the page */
-              //Source: http://www.webpagetest.org/result/151226_X7_b43d35e592fab70e0ba012fe11a41020/
-              // window["fetch"]("test-data/www.bbc.co.uk.160529_8V_7R3.har")
-              // window["fetch"]("test-data/www.bbc.com.har")
-              window["fetch"]("test-data/github.com.MODIFIED.151226_X7_b43d35e592fab70e0ba012fe11a41020.har")
-                      .then(f => f.json().then(j => renderPerfCascadeChart(j.log)))
-          }
-
-        /** hook up file input events */
-        document.getElementById("fileinput").addEventListener("change", onFileSubmit, false)
+      setup({pageSelector: pageSelectorEl, legendHolder: legendHolderEl}, "fileinput", outputHolderEl);
+      setup({pageSelector: pageSelector2El}, "fileinput2", outputHolder2El);
       })(window.perfCascade)
     </script>
 </body>


### PR DESCRIPTION
This is two make it easier to catch changes that break multiple waterfalls on the same page. Detected and corrected some minor issues with the example page css to make it work with more than one waterfall.