### PR TITLE
Global changePage api doesn't work with multiple waterfalls.

### DIFF
--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -71,7 +71,6 @@ let transformHarToPerfCascade = HarTransformer.transformDoc;
 export { fromHar }
 export { fromPerfCascadeFormat }
 export { transformHarToPerfCascade }
-export { setSelectedPageIndex as changePage } from "./paging/paging"
 export { makeLegend }
 // export typings
 export * from "./typing/index.d"


### PR DESCRIPTION
Don’t export a global changePage function to programmatic paging
control, since it doesn’t provide control over what waterfall to page.
The api already allows for a per-waterfall pager element. That gives
programmatic access via the standard DOM api for select boxes.