### PR TITLE
Detect svg files as such, not generic images.

### DIFF
--- a/src/ts/helpers/icons.ts
+++ b/src/ts/helpers/icons.ts
@@ -145,7 +145,11 @@ export function image(x: number, y: number, title: string, scale: number = 1): S
     0,0.6188 -0.440625,1.0594 Q 17.11875,16.2 16.5,16.2 l -15,0 Q 0.88125,16.2 0.440625,15.7594 0,15.3188 0,14.7 L 0,3.3
     Q 0,2.6813 0.440625,2.2406 0.88125,1.8 1.5,1.8 l 15,0 q 0.61875,0 1.059375,0.4406 Q 18,2.6813 18,3.3 Z" />`); }
 
-export function html(x: number, y: number, title: string, scale: number = 1): SVGElement {
+export function svg(x: number, y: number, title: string, scale: number = 1): SVGElement {
+  return image(x, y, title, scale);
+}
+
+  export function html(x: number, y: number, title: string, scale: number = 1): SVGElement {
   return toSvg(x, y, title, "icon-html", scale, `<path d="m 5.62623,13.310467 -0.491804,0.4919 q -0.09836,0.098
     -0.226229,0.098 -0.127869,0 -0.22623,-0.098 L 0.098361,9.218667 Q 0,9.120367 0,8.992467 q 0,-0.1279 0.09836,-0.2262
     l 4.583606,-4.5836 q 0.09836,-0.098 0.22623,-0.098 0.127869,0 0.226229,0.098 l 0.491804,0.4918 q 0.09836,0.098

--- a/src/ts/transformers/har.ts
+++ b/src/ts/transformers/har.ts
@@ -54,14 +54,18 @@ function mimeToRequestType(mimeType: string): RequestType {
     part2 = part2.indexOf(";") > -1 ? part2.split(";")[0] : part2;
   }
   switch (types[0]) {
-    case "image": return "image";
+    case "image": {
+      if (part2 === "svg+xml") {
+        return "svg";
+      }
+      return "image";
+    }
     case "font": return "font";
     case "video": return "video";
     case "audio": return "audio";
     default: break;
   }
   switch (part2) {
-    case "svg+xml": return "svg";
     case "xml":
     case "html": return "html";
     case "plain": return "plain";


### PR DESCRIPTION
Update mime type check to classify image/svg+xml as svg, not a generic image. This fixes two issues:
- Svg images now show ”svg” when hovering over the icon (for now it reuses the same icon as ”image” files.
- Check for compression issues not applies to svg files as well.