### PR TITLE
Remove unneeded namespace prefix from svg.

### DIFF
--- a/src/ts/helpers/svg.ts
+++ b/src/ts/helpers/svg.ts
@@ -60,7 +60,7 @@ function newElement<T extends StylableSVGElement>(tagName: string,
 }
 
 export function newSvg(className: string, attributes: DomAttributeMap, css: CssStyleMap = {}): SVGSVGElement {
-  return newElement<SVGSVGElement>("svg:svg", {className, attributes, css});
+  return newElement<SVGSVGElement>("svg", {className, attributes, css});
 }
 
 export function newG(className: string, attributes: DomAttributeMap = {}, css: CssStyleMap = {}): SVGGElement {


### PR DESCRIPTION
Svg elements (except for mimetype icons) currently include a namespace prefix. This is not needed, and makes the resulting markup slightly less readable. All svg elements are still created with the http://www.w3.org/2000/svg namespace URI.