### PR TITLE
Don’t merge request number and url.

### DIFF
--- a/src/ts/waterfall/row/svg-row-subcomponents.ts
+++ b/src/ts/waterfall/row/svg-row-subcomponents.ts
@@ -110,6 +110,21 @@ export function createRect(rectData: RectData, segments: WaterfallEntryTiming[],
 }
 
 /**
+ * Create a SVG text element for the request number label, right aligned within the specified width.
+ * @param {number} x horizontal position (in px).
+ * @param {number} y vertical position of related request block (in px).
+ * @param {string} requestNumber the request number string
+ * @param {number} height height of row
+ * @param {number} width width of the space within the right align the label.
+ * @returns {SVGTextElement}
+ */
+export function createRequestNumberLabel(x: number, y: number, requestNumber: string, height: number, width: number) {
+  y += Math.round(height / 2) + 5;
+  x += width;
+  return svg.newTextEl(requestNumber, {x, y}, {"text-anchor": "end"});
+}
+
+/**
  * Create a new clipper SVG Text element to label a request block to fit the left panel width
  * @param  {number}         x                horizontal position (in px)
  * @param  {number}         y                vertical position of related request block (in px)
@@ -162,16 +177,19 @@ function createRequestLabel(x: number, y: number, name: string, height: number):
 /**
  * Appends the labels to `rowFixed` - TODO: see if this can be done more elegant
  * @param {SVGGElement}    rowFixed   [description]
+ * @param {SVGTextElement} requestNumberLabel a label placed in front of every shortLabel
  * @param {SVGTextElement} shortLabel [description]
  * @param {SVGGElement}    fullLabel  [description]
  */
-export function appendRequestLabels(rowFixed: SVGGElement, shortLabel: SVGTextElement, fullLabel: SVGGElement) {
+export function appendRequestLabels(rowFixed: SVGGElement, requestNumberLabel: SVGTextElement,
+                                    shortLabel: SVGTextElement, fullLabel: SVGGElement) {
   let labelFullBg = fullLabel.getElementsByTagName("rect")[0] as SVGRectElement;
   let fullLabelText = fullLabel.getElementsByTagName("text")[0] as SVGTextElement;
 
   // use display: none to not render it and visibility to remove it from search results (crt+f in chrome at least)
   fullLabel.style.display = "none";
   fullLabel.style.visibility = "hidden";
+  rowFixed.appendChild(requestNumberLabel);
   rowFixed.appendChild(shortLabel);
   rowFixed.appendChild(fullLabel);
 

--- a/src/ts/waterfall/row/svg-row.ts
+++ b/src/ts/waterfall/row/svg-row.ts
@@ -1,8 +1,9 @@
-import * as heuristics from "../../helpers/heuristics";
+import { isInStatusCodeRange } from "../../helpers/heuristics";
 import * as icons from "../../helpers/icons";
 import * as misc from "../../helpers/misc";
 import * as svg from "../../helpers/svg";
 import { Context } from "../../typing/context";
+import {Entry} from "../../typing/har";
 import { RectData } from "../../typing/rect-data";
 import {WaterfallEntry} from "../../typing/waterfall";
 import * as indicators from "./svg-indicators";
@@ -15,27 +16,32 @@ clipPathElProto.appendChild(svg.newRect({
   "width": "100%",
 }));
 
+function getRowCssClasses(harEntry: Entry): string {
+  const classes = ["row-item"];
+  if (isInStatusCodeRange(harEntry, 500, 599)) {
+    classes.push("status5xx");
+  } else if (isInStatusCodeRange(harEntry, 400, 499)) {
+    classes.push("status4xx");
+  } else if (harEntry.response.status !== 304 &&
+    isInStatusCodeRange(harEntry, 300, 399)) {
+    // 304 == Not Modified, so not an issue
+    classes.push("status3xx");
+  }
+  return classes.join(" ");
+}
+
+const ROW_LEFT_MARGIN = 3;
+
 // Create row for a single request
-export function createRow(context: Context, index: number, rectData: RectData, entry: WaterfallEntry,
-                          labelXPos: number, onDetailsOverlayShow: EventListener): SVGGElement {
+export function createRow(context: Context, index: number,
+                          maxIconsWidth: number, maxNumberWidth: number,
+                          rectData: RectData, entry: WaterfallEntry,
+                          onDetailsOverlayShow: EventListener): SVGGElement {
 
   const y = rectData.y;
   const rowHeight = rectData.height;
   const leftColumnWith = context.options.leftColumnWith;
-
-  let rowCssClass = ["row-item"];
-  if (heuristics.isInStatusCodeRange(entry.rawResource, 500, 599)) {
-    rowCssClass.push("status5xx");
-  }
-  if (heuristics.isInStatusCodeRange(entry.rawResource, 400, 499)) {
-    rowCssClass.push("status4xx");
-  } else if (entry.rawResource.response.status !== 304 &&
-    heuristics.isInStatusCodeRange(entry.rawResource, 300, 399)) {
-    // 304 == Not Modified, so not an issue
-    rowCssClass.push("status3xx");
-  }
-
-  let rowItem = svg.newG(rowCssClass.join(" "));
+  let rowItem = svg.newG(getRowCssClasses(entry.rawResource));
   let leftFixedHolder = svg.newSvg("left-fixed-holder", {
     "width": `${leftColumnWith}%`,
     "x": "0",
@@ -45,21 +51,12 @@ export function createRow(context: Context, index: number, rectData: RectData, e
     "x": `${leftColumnWith}%`,
   });
 
-  let requestNumber = `${index + 1}. `;
-
   let rect = rowSubComponents.createRect(rectData, entry.segments, entry.total);
-  let shortLabel = rowSubComponents.createRequestLabelClipped(labelXPos, y,
-    requestNumber + misc.resourceUrlFormatter(entry.name, 40), rowHeight);
-  let fullLabel = rowSubComponents.createRequestLabelFull(labelXPos, y, requestNumber + entry.name, rowHeight);
-
   let rowName = rowSubComponents.createNameRowBg(y, rowHeight, onDetailsOverlayShow);
   let rowBar = rowSubComponents.createRowBg(y, rowHeight, onDetailsOverlayShow);
   let bgStripe = rowSubComponents.createBgStripe(y, rowHeight, (index % 2 === 0));
 
-  // create and attach request block
-  rowBar.appendChild(rect);
-
-  let x = 3;
+  let x = ROW_LEFT_MARGIN;
 
   if (context.options.showMimeTypeIcon) {
     const icon = indicators.getMimeTypeIcon(entry);
@@ -74,7 +71,23 @@ export function createRow(context: Context, index: number, rectData: RectData, e
       x += icon.width;
     });
   }
-  rowSubComponents.appendRequestLabels(rowName, shortLabel, fullLabel);
+
+  // Jump to the largest offset of all rows
+  x = ROW_LEFT_MARGIN + maxIconsWidth;
+
+  let requestNumber = `${index + 1}`;
+
+  const requestNumberLabel = rowSubComponents.createRequestNumberLabel(x, y, requestNumber, rowHeight, maxNumberWidth);
+  // 4 is slightly bigger than the hover "glow" around the url
+  x += maxNumberWidth + 4;
+  let shortLabel = rowSubComponents.createRequestLabelClipped(x, y, misc.resourceUrlFormatter(entry.name, 40),
+    rowHeight);
+  let fullLabel = rowSubComponents.createRequestLabelFull(x, y, entry.name, rowHeight);
+
+  // create and attach request block
+  rowBar.appendChild(rect);
+
+  rowSubComponents.appendRequestLabels(rowName, requestNumberLabel, shortLabel, fullLabel);
 
   flexScaleHolder.appendChild(rowBar);
   leftFixedHolder.appendChild(clipPathElProto.cloneNode(true));

--- a/src/ts/waterfall/svg-chart.ts
+++ b/src/ts/waterfall/svg-chart.ts
@@ -17,14 +17,14 @@ import * as marks from  "./sub-components/svg-marks";
 
 /**
  * Get a string that's as wide, or wider than any number from 0-n.
- * @param n
+ * @param {number} n the highest number that should fit within the returned string's width.
  * @returns {string}
  */
 function getWidestDigitString(n: number): string {
   const numDigits = Math.floor((Math.log(n) / Math.LN10)) + 1;
   let s = "";
   for (let i = 0; i < numDigits; i++) {
-    // No number should take more horizonal space than 0 to write.
+    // No number should take more horizontal space than "0" does.
     s += "0";
   }
   return s;


### PR DESCRIPTION
Put request number in a separate <text> element, so request url is shown unchanged (in hover and title). Right aligns the request number, and aligns the start position of all urls. Additionally reorders some code in row svg creation.