### PR TITLE
#137 add a Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+
+

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,15 +1,19 @@
 const path = require("path");
 const process = require("process");
 const gruntBump = require("grunt-bump")
-
+/**
+ * @param  {IGrunt} grunt - Grunt instance
+ */
 module.exports = function (grunt) {
   "use strict";
-
 
   /** Version banner for static files (keep version format for "grunt-bump") */
   const banner = "/*! github.com/micmro/PerfCascade Version:<%= package.version %> <%= grunt.template.today(\"(dd/mm/yyyy)\") %> */\n";
   let releaseIncrement = ["major", "minor"]
     .indexOf(grunt.option('release-increment')) != -1 ? grunt.option('release-increment') : "patch";
+
+  // manually load custom task
+  require("./build-utils/grunt-tasks/changelog-custom")(grunt)
 
   // automatically loads configurations from `./grunt-config/*`
   require('load-grunt-config')(grunt, {
@@ -60,6 +64,7 @@ module.exports = function (grunt) {
     "preBuild",
     `bump-only:${releaseIncrement}`,
     "releaseBuild",
+    "changelog-custom",
     "commitAndPush"
   ]);
 

--- a/build-utils/grunt-config/changelog-custom.js
+++ b/build-utils/grunt-config/changelog-custom.js
@@ -3,4 +3,4 @@ module.exports = {
     version: 'v<%= package.version %>',
     file: 'CHANGELOG.md'
   }
-}
+};

--- a/build-utils/grunt-config/changelog-custom.js
+++ b/build-utils/grunt-config/changelog-custom.js
@@ -1,0 +1,6 @@
+module.exports = {
+  options: {
+    version: 'v<%= package.version %>',
+    file: 'CHANGELOG.md'
+  }
+}

--- a/build-utils/grunt-config/gh-pages.js
+++ b/build-utils/grunt-config/gh-pages.js
@@ -5,4 +5,4 @@ module.exports = {
     message: "Github Pages release for v<%= package.version %>"
   },
   src: ["**/*"]
-}
+};

--- a/build-utils/grunt-config/run.js
+++ b/build-utils/grunt-config/run.js
@@ -27,7 +27,6 @@ module.exports = {
     options: {
       cwd: process.cwd()
     },
-    exec: `(export VERSION=<%= package.version %> && bash build-utils/release.sh)`
-
+    exec: `(export VERSION=<%= package.version %> && export CHANGELOG="<%= changelog %>" && bash build-utils/release.sh)`
   }
 };

--- a/build-utils/grunt-config/run.js
+++ b/build-utils/grunt-config/run.js
@@ -14,7 +14,7 @@ module.exports = {
     --rootDir src/ts/
     --declaration true
     --declarationDir ./build/npm/types
-    `.replace(/\n[\t ]+/g,' ').split(' ').filter(x => x != '')
+    `.replace(/\n[\t ]+/g, ' ').split(' ').filter(x => x != '')
   },
   npmPublish: {
     options: {
@@ -27,6 +27,6 @@ module.exports = {
     options: {
       cwd: process.cwd()
     },
-    exec: `(export VERSION=<%= package.version %> && export CHANGELOG="<%= changelog %>" && bash build-utils/release.sh)`
+    exec: `(export VERSION='<%= package.version %>' && export CHANGELOG='<%= changelog %>' && bash build-utils/release.sh)`
   }
 };

--- a/build-utils/grunt-tasks/changelog-custom.js
+++ b/build-utils/grunt-tasks/changelog-custom.js
@@ -1,0 +1,43 @@
+let fs = require('fs')
+let conventionalChangelog = require('conventional-changelog');
+
+/**
+ * @param  {IGrunt} grunt - Grunt instance
+ */
+module.exports = function(grunt){
+  let PassThroughStream = require('stream').PassThrough;
+
+  grunt.registerTask('changelog-custom', 'Custom version of changelog', function() {
+    const done = this.async();
+    const options = this.options()
+    let readDataStream = new PassThroughStream();
+    let tmpBuffer = "";
+
+    // extract data
+    readDataStream
+      .on('data', (chunk) => tmpBuffer += chunk)
+      .on('end', () => {
+        grunt.config.data.changelog = tmpBuffer
+        readDataStream.end()
+      })
+
+    // changlog file writer
+    let appenFileStream = fs.createWriteStream(options.file, {'flags': 'a'})
+      .on('error', grunt.log.error)
+      .on('close', () => {
+        grunt.log.ok(`${options.file} updated with latest changelog for ${options.version}`)
+        done();
+      })
+
+    // get changelog
+    conventionalChangelog({
+      config: {
+        warn : grunt.warn,
+        pkg: grunt.package
+      }
+    }, {
+      version: options.version
+    }).pipe(readDataStream).pipe(appenFileStream) // or any writable stream
+  });
+
+}

--- a/build-utils/grunt-tasks/changelog-custom.js
+++ b/build-utils/grunt-tasks/changelog-custom.js
@@ -1,15 +1,26 @@
-let fs = require('fs')
+let fs = require('fs');
 let conventionalChangelog = require('conventional-changelog');
+
+/**
+ * Escape string to be used as bash argument
+ * assumes strong quoting (using single qotes)
+ * @param  {string} str
+ */
+const escapeForBash = (str) => {
+  return JSON.stringify(str)
+    .replace(/^"|"$/g, '') //remove JSON-string double quotes
+    .replace(/'/g, '\'"\'"\''); //escape single quotes the ugly bash way
+};
 
 /**
  * @param  {IGrunt} grunt - Grunt instance
  */
-module.exports = function(grunt){
+module.exports = function (grunt) {
   let PassThroughStream = require('stream').PassThrough;
 
-  grunt.registerTask('changelog-custom', 'Custom version of changelog', function() {
+  grunt.registerTask('changelog-custom', 'Custom version of changelog', function () {
     const done = this.async();
-    const options = this.options()
+    const options = this.options();
     let readDataStream = new PassThroughStream();
     let tmpBuffer = "";
 
@@ -17,27 +28,28 @@ module.exports = function(grunt){
     readDataStream
       .on('data', (chunk) => tmpBuffer += chunk)
       .on('end', () => {
-        grunt.config.data.changelog = tmpBuffer
-        readDataStream.end()
-      })
+        let lines = tmpBuffer.split("\n");
+        lines.shift(); //remove the html-ancor tag in the first line
+        grunt.config.data.changelog = escapeForBash(lines.join('\n'));
+        readDataStream.end();
+      });
 
     // changlog file writer
-    let appenFileStream = fs.createWriteStream(options.file, {'flags': 'a'})
+    let appenFileStream = fs.createWriteStream(options.file, { 'flags': 'a' })
       .on('error', grunt.log.error)
       .on('close', () => {
-        grunt.log.ok(`${options.file} updated with latest changelog for ${options.version}`)
+        grunt.log.ok(`${options.file} updated with latest changelog for ${options.version}`);
         done();
-      })
+      });
 
     // get changelog
     conventionalChangelog({
       config: {
-        warn : grunt.warn,
+        warn: grunt.warn,
         pkg: grunt.package
       }
     }, {
-      version: options.version
-    }).pipe(readDataStream).pipe(appenFileStream) // or any writable stream
+        version: options.version
+      }).pipe(readDataStream).pipe(appenFileStream); // or any writable stream
   });
-
-}
+};

--- a/build-utils/release.sh
+++ b/build-utils/release.sh
@@ -11,24 +11,21 @@
 
 echo "Start Github release for ${VERSION}..."
 
-CHANGELOG=${CHANGELOG}
+CHANGELOG="${CHANGELOG:-}"
 
 ###
 # Github Release
 ###
 [ -d .release ] && rm -rf .release
-git clone -b release git@github.com:micmro/PerfCascade.git .release
-
-# TODO: test this alternative (might be faster as it only uses one branch)
-# git init
-# git remote add -t refspec remotename git@github.com:micmro/PerfCascade.git
-# git fetch
+git clone -b release \
+  --branch=release \
+  --single-branch \
+  git@github.com:micmro/PerfCascade.git \
+  .release
 
 cd .release
-
-# TODO test
+# remove all to ensure deleted files get deleted as well
 git rm -rf .
-# git clean -fxd
 
 # Copy files
 cp -r ../build/release/ .
@@ -51,5 +48,5 @@ curl \
   -H "Authorization: token ${GITHUB_TOKEN}" \
   https://api.github.com/repos/micmro/PerfCascade/releases
 
-echo "Github release done - cleanup..."
+# echo "Github release done - cleanup..."
 # rm -rf .release

--- a/build-utils/release.sh
+++ b/build-utils/release.sh
@@ -2,6 +2,8 @@
 # release.sh
 # assumes to run in repo root
 
+set -e #exit on errors
+
 # load (private) environment variables like RELEASE_KEY from non-commited file
 . ./ENV_VARS
 
@@ -12,6 +14,7 @@
 echo "Start Github release for ${VERSION}..."
 
 CHANGELOG="${CHANGELOG:-}"
+API_JSON=$(printf '{"body": "%s"}' "${CHANGELOG}")
 
 ###
 # Github Release
@@ -39,9 +42,6 @@ git tag "v$VERSION"
 git push --follow-tags
 
 echo "make Github release"
-# make releases
-# TODO: make final not draft once confirmed working
-# TODO: add Changelog
 API_JSON=$(printf '{"tag_name": "v%s", "target_commitish": "release", "name": "v%s", "body": "%s", "draft": false, "prerelease": false}' $VERSION $VERSION $CHANGELOG)
 curl \
   --data "$API_JSON" \

--- a/build-utils/release.sh
+++ b/build-utils/release.sh
@@ -9,8 +9,9 @@
 : "${VERSION?Need to set VERSION environment variable}"
 : "${GITHUB_TOKEN?Need to set GITHUB_TOKEN environment variable}"
 
-
 echo "Start Github release for ${VERSION}..."
+
+CHANGELOG=${CHANGELOG}
 
 ###
 # Github Release
@@ -44,7 +45,7 @@ echo "make Github release"
 # make releases
 # TODO: make final not draft once confirmed working
 # TODO: add Changelog
-API_JSON=$(printf '{"tag_name": "v%s", "target_commitish": "release", "name": "v%s", "body": "Release of version %s", "draft": false, "prerelease": false}' $VERSION $VERSION $VERSION)
+API_JSON=$(printf '{"tag_name": "v%s", "target_commitish": "release", "name": "v%s", "body": "%s", "draft": false, "prerelease": false}' $VERSION $VERSION $CHANGELOG)
 curl \
   --data "$API_JSON" \
   -H "Authorization: token ${GITHUB_TOKEN}" \

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   "types": "./index.d.ts",
   "license": "MIT",
   "devDependencies": {
+    "@types/grunt": "^0.4.21",
+    "conventional-changelog": "^1.1.0",
     "grunt": "^1.0.1",
     "grunt-banner": "^0.6.0",
     "grunt-browserify": "^5.0.0",


### PR DESCRIPTION
Add a `CHANGELOG.md` and individual changelogs with each github release (containing all commit messages since last release).

All is run automatically with the release task.

Still need to fully run it on master, but on test branches it all seemed to work well.