### PR TITLE
Don’t format small sizes as kB.

### DIFF
--- a/src/ts/helpers/parse.ts
+++ b/src/ts/helpers/parse.ts
@@ -87,6 +87,16 @@ export function formatDateLocalized(date: Date): string {
   return `${date.toUTCString()}</br>(local time: ${date.toLocaleString()})`;
 }
 
+const BYTES_PER_KB = 1024;
+const BYTES_PER_MB = 1014 * BYTES_PER_KB;
+
 export function formatBytes(bytes: number): string {
-  return `${bytes} bytes (~${roundNumber(bytes / 1024, 1)} kb)`;
+  const raw = `${bytes} bytes`;
+  if (bytes >= BYTES_PER_MB) {
+    return `${raw} (~${roundNumber(bytes / BYTES_PER_KB, 1)} MB)`;
+  }
+  if (bytes >= BYTES_PER_KB) {
+    return `${raw} (~${roundNumber(bytes / BYTES_PER_KB, 0)} kB)`;
+  }
+  return raw;
 }

--- a/src/ts/helpers/parse.ts
+++ b/src/ts/helpers/parse.ts
@@ -88,7 +88,7 @@ export function formatDateLocalized(date: Date): string {
 }
 
 const BYTES_PER_KB = 1024;
-const BYTES_PER_MB = 1014 * BYTES_PER_KB;
+const BYTES_PER_MB = 1024 * BYTES_PER_KB;
 
 export function formatBytes(bytes: number): string {
   const raw = `${bytes} bytes`;


### PR DESCRIPTION
Currently byte sizes are always shown with a kb approximation. This is not helpful for  small sizes, e.g. 5 bytes (~0 kb). Instead leave out the kb approximation for sizes < 1kB. Also:
- change from kb (kilobit) to kB (kilobyte)
- show as MB for sizes >= 1MB
- don’t use decimals for approximate sizes < 1MB. The difference between e.g. 67 kB and 68 kB is small, and integer sizes are more glanceable.