### PR TITLE
184 - Marker updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,37 +40,48 @@ Directories:
 see [options.d.ts](https://github.com/micmro/PerfCascade/blob/master/src/ts/typing/options.ts) for source
 
 ### `rowHeight`
-`number`, default: `23`
+`number`, default: `23`<br/>
 Height of every request bar block plus spacer pixel (in px) default: 23
 
 ### `showAlignmentHelpers`
-`boolean`, default: `true`
+`boolean`, default: `true`<br/>
 Show verticale lines to easier spot potential dependencies/blocking between requests
 
 ### `showMimeTypeIcon`
-`boolean`, default: `true`
+`boolean`, default: `true`<br/>
 Show mime type icon on the left
 
 ### `showIndicatorIcons`
-`boolean`, default: `true`
+`boolean`, default: `true`<br/>
 Show warning icons for potential issues on the left
 
 ### `leftColumnWith`
-`number` default: `25`
+`number`, default: `25`<br/>
 Relative width of the info column on the left (in percent)
 
 ### `pageSelector`
-`HTMLSelectElement` default: `undefined`
+`HTMLSelectElement`, default: `undefined`<br/>
 DOM `<select>` element to use to select a run if the HAR contains multiple runs.
 
 ### `selectedPage`
-`number` default: `0`
+`number`, default: `0`<br/>
 Zero-based index of the page to initially render.<br/>
 If `selectedPage` is larger than the number of pages the last page will be selected.
 
 ### `legendHolder`
-`HTMLElement` (DOM element) default: `undefined` (not shown)
+`HTMLElement` (DOM element), default: `undefined` (not shown)<br/>
 If set a legend explaining the waterfall colours is rendered in the `legendHolder` DOM element.
+
+### `showUserTiming`
+`boolean`, default: `false`<br/>
+If enabled the [UserTiming](https://developer.mozilla.org/en-US/docs/Web/API/User_Timing_API) data
+in WebPageTest's format `_userTime.*` get parsed and rendered as well.
+Matching `_userTime.startTimer-*` and `_userTime.endTimer-*` entries get combined into one block.
+
+### `showUserTimingEndMarker`
+`boolean`, default: `false` (requires `showUserTiming` to be `true`)<br/>
+If `showUserTiming` is enabled all `_userTime.endTimer-*` marker are hidden by default, only the UserTiming's
+start and duration is shown. This option also adds an `_userTime.endTimer-*` marker.
 
 ## `*.zhar` - zipped HAR files
 By loading `/perf-cascade-file-reader.min.js` as in [this example](https://github.com/micmro/PerfCascade/blob/master/src/index.html#L78-L86) you can use `perfCascadeFileReader.readFile` to read a zip file and convert it to a JSON HAR object.

--- a/src/css-raw/perf-cascade.css
+++ b/src/css-raw/perf-cascade.css
@@ -19,6 +19,10 @@
 .water-fall-chart .line-end.active,
 .water-fall-chart .line-start.active {display: block;}
 
+.water-fall-chart .line-mark {fill: #0aa; opacity: 0.01; stroke-width: 0;}
+.water-fall-chart .line-holder.active .line-mark { opacity: 0.5;}
+.water-fall-chart .line-label-holder {cursor: pointer;}
+
 .water-fall-chart .mark-holder text {writing-mode:vertical-lr;}
 
 .left-fixed-holder .label-full-bg {fill: #fff; opacity: 0.9}

--- a/src/css-raw/perf-cascade.css
+++ b/src/css-raw/perf-cascade.css
@@ -6,8 +6,11 @@
 
 .water-fall-chart .left-fixed-holder {overflow: visible;}
 .water-fall-chart .marker-holder {width:100%;}
-.water-fall-chart .line-holder {stroke-width:1; stroke: #ccc; stroke-opacity:0.5;}
+.water-fall-chart .line-label-holder {cursor: pointer;}
+.water-fall-chart .line-holder {stroke-width:1; stroke: #ccc; stroke-opacity:0.5; transition: all 60ms;}
+.water-fall-chart .line-holder .line-mark {fill: #69009e; opacity: 0.01; stroke-width: 0; transition: all 60ms;}
 .water-fall-chart .line-holder.active {stroke: #69009e; stroke-width:2; stroke-opacity:1;}
+.water-fall-chart .line-holder.active .line-mark { opacity: 0.4;}
 .water-fall-chart .type-onload .line-holder  {stroke: #c0c0ff;}
 .water-fall-chart .type-oncontentload .line-holder  {stroke: #d888df;}
 
@@ -18,10 +21,6 @@
 .water-fall-chart .line-start {display: none; stroke-width:1; stroke-opacity:0.5; stroke: #000;}
 .water-fall-chart .line-end.active,
 .water-fall-chart .line-start.active {display: block;}
-
-.water-fall-chart .line-mark {fill: #0aa; opacity: 0.01; stroke-width: 0;}
-.water-fall-chart .line-holder.active .line-mark { opacity: 0.5;}
-.water-fall-chart .line-label-holder {cursor: pointer;}
 
 .water-fall-chart .mark-holder text {writing-mode:vertical-lr;}
 

--- a/src/ts/helpers/misc.ts
+++ b/src/ts/helpers/misc.ts
@@ -68,10 +68,21 @@ export function roundNumber(num: number, decimals: number = 2) {
 /**
  *
  * Checks if `status` code is `>= lowerBound` and `<= upperBound`
- * @param  {number} entry
- * @param  {number} lowerBound - inclusive lower bound
- * @param  {number} upperBound - inclusive upper bound
+ * @param  {number} status  HTTP status code
+ * @param  {number} lowerBound  inclusive lower bound
+ * @param  {number} upperBound  inclusive upper bound
  */
 export function isInStatusCodeRange(status: number, lowerBound: number, upperBound: number) {
   return status >= lowerBound && status <= upperBound;
+}
+
+/** precompiled regex */
+const cssClassRegEx = /[^a-z-]/g;
+
+/**
+ * Converts a seed string to a CSS class by stripping out invalid characters
+ * @param {string} seed string to base the CSS class off
+ */
+export function toCssClass(seed: string) {
+  return seed.toLowerCase().replace(cssClassRegEx, "");
 }

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -3,7 +3,7 @@ import { validateOptions } from "./helpers/parse";
 import { makeLegend } from "./legend/legend";
 import Paging from "./paging/paging";
 import * as HarTransformer from "./transformers/har";
-import { ChartOptions } from "./typing/options";
+import { ChartOptions, HarTransformerOptions } from "./typing/options";
 import { WaterfallDocs } from "./typing/waterfall";
 import { createWaterfallSvg } from "./waterfall/svg-chart";
 
@@ -18,6 +18,12 @@ const defaultOptions: Readonly<ChartOptions> = {
   showAlignmentHelpers: true,
   showIndicatorIcons: true,
   showMimeTypeIcon: true,
+};
+
+/** default options to use if not set in `options` parameter */
+const defaultHarTransformerOptions: Readonly<HarTransformerOptions> = {
+  showUserTiming: false,
+  showUserTimingEndMarker: false,
 };
 
 function PerfCascade(waterfallDocsData: WaterfallDocs, chartOptions: Partial<ChartOptions> = {}): SVGSVGElement {
@@ -53,8 +59,12 @@ function PerfCascade(waterfallDocsData: WaterfallDocs, chartOptions: Partial<Cha
  * @param  {ChartOptions} options - PerfCascade options object
  * @returns {SVGSVGElement} - Chart SVG Element
  */
-function fromHar(harData: Har, options: Partial<ChartOptions> = {}): SVGSVGElement {
-  const data = HarTransformer.transformDoc(harData);
+function fromHar(harData: Har, options: Partial<ChartOptions & HarTransformerOptions> = {}): SVGSVGElement {
+  const harTransformerOptions: HarTransformerOptions = {
+    ...defaultHarTransformerOptions,
+    ...options as Partial<HarTransformerOptions>
+  };
+  const data = HarTransformer.transformDoc(harData, harTransformerOptions);
   if (typeof options.onParsed === "function") {
     options.onParsed(data);
   }

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -62,7 +62,7 @@ function PerfCascade(waterfallDocsData: WaterfallDocs, chartOptions: Partial<Cha
 function fromHar(harData: Har, options: Partial<ChartOptions & HarTransformerOptions> = {}): SVGSVGElement {
   const harTransformerOptions: HarTransformerOptions = {
     ...defaultHarTransformerOptions,
-    ...options as Partial<HarTransformerOptions>
+    ...options as Partial<HarTransformerOptions>,
   };
   const data = HarTransformer.transformDoc(harData, harTransformerOptions);
   if (typeof options.onParsed === "function") {

--- a/src/ts/transformers/har.ts
+++ b/src/ts/transformers/har.ts
@@ -249,7 +249,7 @@ const buildDetailTimingBlocks = (startRelative: number, harEntry: Entry): Waterf
  * @param  {number} startRelative - Number of milliseconds since page load started (`page.startedDateTime`)
  * @returns {Object}
  */
-const getTimePair =(key: string, harEntry: Entry, collect: WaterfallEntryTiming[], startRelative: number) => {
+const getTimePair = (key: string, harEntry: Entry, collect: WaterfallEntryTiming[], startRelative: number) => {
   let wptKey;
   switch (key) {
     case "wait": wptKey = "ttfb"; break;
@@ -266,7 +266,7 @@ const getTimePair =(key: string, harEntry: Entry, collect: WaterfallEntryTiming[
     "end": Math.round(end),
     "start": Math.round(start),
   };
-}
+};
 
 /**
  * Helper to create a requests `WaterfallResponseDetails`
@@ -284,4 +284,4 @@ const createResponseDetails = (entry: Entry, indicators: WaterfallEntryIndicator
     requestType,
     statusCode: entry.response.status,
   };
-}
+};

--- a/src/ts/transformers/har.ts
+++ b/src/ts/transformers/har.ts
@@ -7,9 +7,11 @@ import {
 } from "har-format";
 import { roundNumber } from "../helpers/misc";
 import { toInt } from "../helpers/parse";
+import { HarTransformerOptions } from "../typing/options";
 import {
   Mark,
   TimingType,
+  UserTiming,
   WaterfallData,
   WaterfallDocs,
   WaterfallEntryIndicator,
@@ -28,16 +30,17 @@ import {
 
 /**
  * Transforms the full HAR doc, including all pages
- * @param  {Har} harData - raw hhar object
+ * @param  {Har} harData - raw HAR object
+ * @param {HarTransformerOptions} options - HAR-parser-specific options
  * @returns WaterfallDocs
  */
-export function transformDoc(harData: Har | Log): WaterfallDocs {
+export function transformDoc(harData: Har | Log, options: HarTransformerOptions): WaterfallDocs {
   // make sure it's the *.log base node
   let data = (harData["log"] !== undefined ? harData["log"] : harData) as Log;
   const pages = getPages(data);
 
   return {
-    pages: pages.map((_page, i) => this.transformPage(data, i)),
+    pages: pages.map((_page, i) => this.transformPage(data, i, options)),
   };
 }
 
@@ -65,7 +68,7 @@ function toWaterFallEntry(entry: Entry, index: number, startRelative: number, is
 }
 
 /** retuns the page or a mock page object */
-function getPages(data: Log) {
+const getPages = (data: Log) => {
   if (data.pages && data.pages.length > 0) {
     return data.pages;
   }
@@ -80,15 +83,18 @@ function getPages(data: Log) {
     startedDateTime: statedTime,
     title: "n/a",
   } as Page];
-}
+};
 
 /**
  * Transforms a HAR object into the format needed to render the PerfCascade
  * @param  {Har} harData - HAR document
  * @param {number=0} pageIndex - page to parse (for multi-page HAR)
+ * @param {HarTransformerOptions} options - HAR-parser-specific options
  * @returns WaterfallData
  */
-export function transformPage(harData: Har | Log, pageIndex: number = 0): WaterfallData {
+export function transformPage(harData: Har | Log,
+                              pageIndex: number = 0,
+                              options: HarTransformerOptions): WaterfallData {
   // make sure it's the *.log base node
   let data = (harData["log"] !== undefined ? harData["log"] : harData) as Log;
 
@@ -116,17 +122,7 @@ export function transformPage(harData: Har | Log, pageIndex: number = 0): Waterf
       return toWaterFallEntry(entry, index, startRelative, isTLS);
     });
 
-  const marks = Object.keys(pageTimings)
-    .filter((k: keyof PageTiming) => (typeof pageTimings[k] === "number" && pageTimings[k] >= 0))
-    .sort((a: string, b: string) => pageTimings[a] > pageTimings[b] ? 1 : -1)
-    .map((k) => {
-      const startRelative: number = pageTimings[k];
-      doneTime = Math.max(doneTime, startRelative);
-      return {
-        "name": `${k.replace(/^[_]/, "")} (${roundNumber(startRelative, 0)} ms)`,
-        "startTime": startRelative,
-      } as Mark;
-    });
+  const marks = getMarks(pageTimings, currPage, options);
 
   // Add 100ms margin to make room for labels
   doneTime += 100;
@@ -136,10 +132,80 @@ export function transformPage(harData: Har | Log, pageIndex: number = 0): Waterf
     durationMs: doneTime,
     entries,
     marks,
-    lines: [],
     title: currPage.title,
   };
 }
+
+/**
+ * Extract all `Mark`s based on `PageTiming` and `UserTiming`
+ * @param {PageTiming} pageTimings - HARs `PageTiming` object
+ * @param {Page} currPage - active page
+ * @param {HarTransformerOptions} options - HAR-parser-specific options
+ */
+const getMarks = (pageTimings: PageTiming, currPage: Page, options: HarTransformerOptions) => {
+  const sortFn = (a: Mark, b: Mark) => a.startTime - b.startTime;
+  const marks = Object.keys(pageTimings)
+    .filter((k: keyof PageTiming) => (typeof pageTimings[k] === "number" && pageTimings[k] >= 0))
+    .map((k) => ({
+      name: `${k.replace(/^[_]/, "")} (${roundNumber(pageTimings[k], 0)} ms)`,
+      startTime: pageTimings[k],
+    } as Mark));
+
+  if (!options.showUserTiming) {
+    return marks.sort(sortFn);
+  }
+
+  return getUserTimimngs(currPage, options)
+    .concat(marks)
+    .sort(sortFn);
+};
+
+/**
+ * Extract all `Mark`s based on `UserTiming`
+ * @param {Page} currPage - active page
+ * @param {HarTransformerOptions} options - HAR-parser-specific options
+ */
+const getUserTimimngs = (currPage: Page, options: HarTransformerOptions) => {
+  let baseFilter = options.showUserTimingEndMarker ?
+    (k: string) => k.indexOf("_userTime.") === 0 :
+    (k: string) => k.indexOf("_userTime.") === 0 && k.indexOf("_userTime.endTimer-") !== 0;
+  let filterFn = baseFilter;
+
+  if (Array.isArray(options.showUserTiming)) {
+    let findTimings = options.showUserTiming;
+    filterFn = (k: string) => (
+      baseFilter(k) &&
+      findTimings.indexOf(k.replace(/^_userTime\./, "")) >= 0
+    );
+  }
+
+  const findName = /^_userTime\.((?:startTimer-)?(.+))$/;
+
+  const extractUserTiming = (k: string) => {
+    let name: string;
+    let fullName: string;
+    let duration: number;
+    [, fullName, name] = findName.exec(k);
+
+    if (fullName !== name && currPage[`_userTime.endTimer-${name}`]) {
+      duration = currPage[`_userTime.endTimer-${name}`] - currPage[k];
+      return {
+        name: fullName,
+        duration,
+        startTime: currPage[k],
+        // x: currPage[k],
+      } as UserTiming;
+    }
+    return {
+      name: fullName,
+      startTime: currPage[k],
+    } as UserTiming;
+  };
+
+  return Object.keys(currPage)
+    .filter(filterFn)
+    .map(extractUserTiming);
+};
 
 /**
  * Create `WaterfallEntry`s to represent the subtimings of a request
@@ -148,7 +214,7 @@ export function transformPage(harData: Har | Log, pageIndex: number = 0): Waterf
  * @param  {Entry} harEntry
  * @returns Array
  */
-function buildDetailTimingBlocks(startRelative: number, harEntry: Entry): WaterfallEntryTiming[] {
+const buildDetailTimingBlocks = (startRelative: number, harEntry: Entry): WaterfallEntryTiming[] => {
   let t = harEntry.timings;
   return ["blocked", "dns", "connect", "send", "wait", "receive"].reduce((collect: WaterfallEntryTiming[],
     key: TimingType) => {
@@ -172,7 +238,7 @@ function buildDetailTimingBlocks(startRelative: number, harEntry: Entry): Waterf
 
     return collect.concat([createWaterfallEntryTiming(key, Math.round(time.start), Math.round(time.end))]);
   }, []);
-}
+};
 
 /**
  * Returns Object containing start and end time of `collect`
@@ -183,7 +249,7 @@ function buildDetailTimingBlocks(startRelative: number, harEntry: Entry): Waterf
  * @param  {number} startRelative - Number of milliseconds since page load started (`page.startedDateTime`)
  * @returns {Object}
  */
-function getTimePair(key: string, harEntry: Entry, collect: WaterfallEntryTiming[], startRelative: number) {
+const getTimePair =(key: string, harEntry: Entry, collect: WaterfallEntryTiming[], startRelative: number) => {
   let wptKey;
   switch (key) {
     case "wait": wptKey = "ttfb"; break;
@@ -209,7 +275,7 @@ function getTimePair(key: string, harEntry: Entry, collect: WaterfallEntryTiming
  * @param  {WaterfallEntryIndicator[]} indicators
  * @returns WaterfallResponseDetails
  */
-function createResponseDetails(entry: Entry, indicators: WaterfallEntryIndicator[]): WaterfallResponseDetails {
+const createResponseDetails = (entry: Entry, indicators: WaterfallEntryIndicator[]): WaterfallResponseDetails => {
   const requestType = mimeToRequestType(entry.response.content.mimeType);
   return {
     icon: makeMimeTypeIcon(entry.response.status, entry.response.statusText, requestType, entry.response.redirectURL),

--- a/src/ts/transformers/har.ts
+++ b/src/ts/transformers/har.ts
@@ -190,7 +190,7 @@ const getUserTimimngs = (currPage: Page, options: HarTransformerOptions) => {
     if (fullName !== name && currPage[`_userTime.endTimer-${name}`]) {
       duration = currPage[`_userTime.endTimer-${name}`] - currPage[k];
       return {
-        name: fullName,
+        name: `${options.showUserTimingEndMarker ? fullName : name} (${currPage[k]} - ${currPage[k] + duration} ms)`,
         duration,
         startTime: currPage[k],
         // x: currPage[k],

--- a/src/ts/transformers/helpers.ts
+++ b/src/ts/transformers/helpers.ts
@@ -1,5 +1,5 @@
 /** Helpers that are not file-fromat specific */
-import { isInStatusCodeRange } from "../helpers/misc";
+import { isInStatusCodeRange, toCssClass } from "../helpers/misc";
 import { escapeHtml } from "../helpers/parse";
 import { RequestType } from "../typing/waterfall";
 import {
@@ -19,8 +19,8 @@ export function makeDefinitionList(dlKeyValues: KvTuple[], addClass: boolean = f
     if (!addClass) {
       return "";
     }
-    let className = key.toLowerCase().replace(/[^a-z-]/g, "");
-    return `class="${className || "no-colour"}"`;
+    let className = toCssClass(key) || "no-colour";
+    return `class="${className}"`;
   };
   return dlKeyValues
     .filter((tuple: KvTuple) => tuple[1] !== undefined)

--- a/src/ts/typing/options.ts
+++ b/src/ts/typing/options.ts
@@ -20,3 +20,15 @@ export interface ChartOptions {
   /** Callback called when the HAR doc has been parsed into PerfCascases */
   onParsed: (data: WaterfallDocs) => void;
 }
+
+export interface HarTransformerOptions {
+  /** Should UserTimings in WPT be used and rendered as Mark (default: false) */
+  showUserTiming: boolean | string[];
+  /**
+   * If this is enabled, the `endTimer-*` marker are shown,
+   * and both start and end show the full `startTimer-*` and `endTimer-*` name. (default: false)
+   *
+   * _requires `showUserTiming` to be `true`_
+   */
+  showUserTimingEndMarker: boolean;
+}

--- a/src/ts/typing/waterfall.ts
+++ b/src/ts/typing/waterfall.ts
@@ -4,12 +4,14 @@ export type RequestType = "other" | "image" | "video" | "audio" | "font" | "svg"
 
 export type IndicatorType = "error" | "warning" | "info";
 
+/** Typing for a event, e.g. UserTiming API performance mark from WPT */
 export interface UserTiming {
   duration?: number;
   name: string;
   startTime: number;
 }
 
+/** Type for a time-marker, e.g. the fireing of an event */
 export interface Mark extends UserTiming {
   /** custom data to store x position */
   x?: number;
@@ -86,17 +88,23 @@ export interface WaterfallResponseDetails {
   requestType: RequestType;
 }
 
+/** Type data used to rendering a single waterfall diagram */
 export interface WaterfallData {
+  /** Page title */
   title: string;
+  /** time to load all contained entries (in ms) */
   durationMs: number;
+  /** Array of requests */
   entries: WaterfallEntry[];
+  /** special time marker e.g. `onLoad` */
   marks: Mark[];
-  lines: WaterfallEntry[];
   /** indicates if the parent document is loaded with TLS or SSL */
   docIsTLS: boolean;
 }
 
+/** Type for a series of waterfall diagrams */
 export interface WaterfallDocs {
+  /** Series of waterfalls (e.g. multiple page-views) */
   pages: WaterfallData[];
 }
 

--- a/src/ts/waterfall/sub-components/svg-general-components.ts
+++ b/src/ts/waterfall/sub-components/svg-general-components.ts
@@ -4,10 +4,8 @@
 
 import { roundNumber } from "../../helpers/misc";
 import * as svg from "../../helpers/svg";
-import { requestTypeToCssClass } from "../../transformers/styling-converters";
 import { Context } from "../../typing/context";
 import { OverlayChangeEvent } from "../../typing/open-overlay";
-import { WaterfallEntry } from "../../typing/waterfall";
 
 /**
  * Renders a per-second marker line and appends it to `timeHolder`
@@ -84,18 +82,4 @@ export function createTimeScale(context: Context, durationMs: number): SVGGEleme
     appendSecond(context, timeHolder, secs, secValue, isMarkerStep);
   }
   return timeHolder;
-}
-
-// TODO: Implement - data for this not parsed yet
-export function createBgRect(context: Context, entry: WaterfallEntry): SVGRectElement {
-  let rect = svg.newRect({
-    "height": context.diagramHeight,
-    "width": ((entry.total || 1) / context.unit) + "%",
-    "x": ((entry.start || 0.001) / context.unit) + "%",
-    "y": 0,
-  }, requestTypeToCssClass(entry.responseDetails.requestType));
-
-  rect.appendChild(svg.newTitle(entry.url)); // Add tile to wedge path
-
-  return rect;
 }

--- a/src/ts/waterfall/sub-components/svg-marks.ts
+++ b/src/ts/waterfall/sub-components/svg-marks.ts
@@ -62,10 +62,12 @@ export function createMarks(context: Context, marks: Mark[]) {
       lineConnection.setAttribute("transform", `translate(0, ${offset})`);
     });
 
-   let isActive = false;
+    let isHoverActive = false;
+    /** click indicator - overwrites `isHoverActive` */
+    let isClickActive = false;
     let onLabelMouseEnter = () => {
-      if (!isActive) {
-        isActive = true;
+      if (!isHoverActive) {
+        isHoverActive = true;
         addClass(lineHolder, "active");
         // firefox has issues with this
         markHolder.parentNode.appendChild(markHolder);
@@ -73,12 +75,22 @@ export function createMarks(context: Context, marks: Mark[]) {
     };
 
     let onLabelMouseLeave = () => {
-      isActive = false;
-      removeClass(lineHolder, "active");
+      isHoverActive = false;
+      if (!isClickActive) {
+        removeClass(lineHolder, "active");
+      }
+    };
+
+    let onLabelClick = () => {
+      isClickActive = !isClickActive;
+      if (!isClickActive) {
+        removeClass(lineHolder, "active");
+      }
     };
 
     lineLabel.addEventListener("mouseenter", onLabelMouseEnter);
     lineLabel.addEventListener("mouseleave", onLabelMouseLeave);
+    lineLabel.addEventListener("click", onLabelClick);
     lineLabelHolder.appendChild(lineLabel);
 
     markHolder.appendChild(svg.newTitle(mark.name));

--- a/src/ts/waterfall/sub-components/svg-marks.ts
+++ b/src/ts/waterfall/sub-components/svg-marks.ts
@@ -60,6 +60,9 @@ export function createMarks(context: Context, marks: Mark[]) {
       line.setAttribute("transform", `scale(1, ${scale})`);
       lineLabelHolder.setAttribute("transform", `translate(0, ${offset})`);
       lineConnection.setAttribute("transform", `translate(0, ${offset})`);
+      if (lineRect) {
+        lineRect.setAttribute("transform", `translate(0, ${offset})`);
+      }
     });
 
     let isHoverActive = false;

--- a/src/ts/waterfall/sub-components/svg-marks.ts
+++ b/src/ts/waterfall/sub-components/svg-marks.ts
@@ -105,7 +105,6 @@ export function createMarks(context: Context, marks: Mark[]) {
   return marksHolder;
 }
 
-
 /**
  * Converts a `Mark` with a duration (e.g. a UserTiming with `startTimer` and `endTimer`) into a rect.
  * @param {Context} context Execution context object

--- a/src/ts/waterfall/sub-components/svg-marks.ts
+++ b/src/ts/waterfall/sub-components/svg-marks.ts
@@ -90,10 +90,18 @@ export function createMarks(context: Context, marks: Mark[]) {
     };
 
     let onLabelClick = () => {
-      isClickActive = !isClickActive;
-      if (!isClickActive) {
+      if (isClickActive) {
+        // deselect
+        isHoverActive = false;
         removeClass(lineHolder, "active");
+      } else if (!isHoverActive) {
+        // for touch devices
+        addClass(lineHolder, "active");
+      } else {
+        isHoverActive = false;
       }
+      // set new state
+      isClickActive = !isClickActive;
     };
 
     lineLabel.addEventListener("mouseenter", onLabelMouseEnter);

--- a/src/ts/waterfall/sub-components/svg-marks.ts
+++ b/src/ts/waterfall/sub-components/svg-marks.ts
@@ -70,10 +70,15 @@ export function createMarks(context: Context, marks: Mark[]) {
     let isClickActive = false;
     let onLabelMouseEnter = () => {
       if (!isHoverActive) {
-        isHoverActive = true;
-        addClass(lineHolder, "active");
-        // firefox has issues with this
+        // move marker to top
         markHolder.parentNode.appendChild(markHolder);
+        isHoverActive = true;
+        // assign class later to not break animation with DOM re-order
+        if (typeof window.requestAnimationFrame === "function") {
+          window.requestAnimationFrame(() => addClass(lineHolder, "active"));
+        } else {
+          addClass(lineHolder, "active");
+        }
       }
     };
 

--- a/src/ts/waterfall/svg-chart.ts
+++ b/src/ts/waterfall/svg-chart.ts
@@ -117,10 +117,6 @@ export function createWaterfallSvg(data: WaterfallData, options: ChartOptions): 
   scaleAndMarksHolder.appendChild(generalComponents.createTimeScale(context, data.durationMs));
   scaleAndMarksHolder.appendChild(marks.createMarks(context, data.marks));
 
-  data.lines.forEach((entry) => {
-    timeLineHolder.appendChild(generalComponents.createBgRect(context, entry));
-  });
-
   // This assumes all icons (mime and indicators) have the same width
   const perIconWidth = entriesToShow[0].responseDetails.icon.width;
 


### PR DESCRIPTION
- allow all Marker to be clicked and stay in active state (click again to toggle)
- add option `showUserTiming` to render all or specific UserTiming Marker (off by default)
- add option `showUserTimingEndMarker` to render `endTimer-*` marker (off by default)
- visualize duration (show block on hover and click) for `startTimer-*` & `endTimer-*` UserTiming
- allow touch devices to highlight marker

Duration:
Inactive:
<img width="358" alt="screen shot 2017-03-22 at 11 17 33 pm" src="https://cloud.githubusercontent.com/assets/1680390/24202225/c79db7e0-0f55-11e7-876f-c07b893e9301.png">
Hover or click:
<img width="325" alt="screen shot 2017-03-22 at 11 17 28 pm" src="https://cloud.githubusercontent.com/assets/1680390/24202224/c798f584-0f55-11e7-8ad4-bfa76b908b24.png">