### PR TITLE
Include marks when calculating largest time for the waterfall graph

### DIFF
--- a/src/ts/transformers/har.ts
+++ b/src/ts/transformers/har.ts
@@ -123,6 +123,12 @@ export function transformPage(harData: Har | Log,
     });
 
   const marks = getMarks(pageTimings, currPage, options);
+  // if marks happens later than doneTime, increase the doneTime
+  marks.forEach((mark) => {
+    if (mark.startTime > doneTime) {
+      doneTime = mark.startTime;
+    }
+  });
 
   // Add 100ms margin to make room for labels
   doneTime += 100;


### PR DESCRIPTION
This is needed for HARs generated on a phone, assets can be downloaded fast but it takes time until everything is ready. When we added support for getting HARs from an Android phone including visual metrics it can happen that metrics are later than the latest asset in the waterfall graph. I think they always should be included.