### PR TITLE
#188 make chart keyboard accessible.

### DIFF
--- a/src/css-raw/perf-cascade.css
+++ b/src/css-raw/perf-cascade.css
@@ -149,8 +149,11 @@
 .info-overlay-holder .tab-nav li {margin: 0; padding: 0; display: inline-block;}
 .info-overlay-holder button { background: transparent; outline:0; border:0; border-bottom: solid 2px transparent; padding: 0.5em 1em; margin:0 0.25em;}
 .info-overlay-holder li:first-child  button {margin-left: 1em;}
-.info-overlay-holder button:focus,.info-overlay-holder button:hover {border-color: rgba(255,255,255, 0.6);}
+.info-overlay-holder button:focus,
+.info-overlay-holder button.active:focus,
+.info-overlay-holder button:hover {border-color: rgba(255,255,255, 0.6);}
 .info-overlay-holder button.active {border-color: #fff; cursor: default;}
+.info-overlay-holder button.active:focus {border-color: rgba(255,255,255, 0.8);}
 
 /* Info overlay HTML - content */
 .info-overlay-holder dt {float: left; clear: both; margin-top: 0.5em; width: 25%; text-align: right; font-weight: bold; }

--- a/src/css-raw/perf-cascade.css
+++ b/src/css-raw/perf-cascade.css
@@ -95,7 +95,7 @@
 .block-undefined {fill: #0f0;}
 
 /* Info overlay SVG - wrapper */
-.info-overlay {fill: #fff; stroke: #cdcdcd;}
+.info-overlay-bg {fill: #fff; stroke: #cdcdcd;}
 .info-overlay-close-btn {fill: rgba(205, 205, 205, 0.8); transform: translate(-23px, -23px); cursor: pointer;}
 .info-overlay-close-btn text {fill: #111; pointer-events: none;}
 .info-overlay-close-btn:focus {border: solid 1px #36c;}

--- a/src/ts/helpers/dom.ts
+++ b/src/ts/helpers/dom.ts
@@ -67,3 +67,8 @@ export function getLastItemOfNodeList<T extends Node>(list: NodeListOf<T>) {
   }
   return list.item(list.length - 1);
 }
+
+// /** Calls `fn` with each element of `els` */
+export function forEachNodeList<T extends Node>(els: NodeListOf<T>, fn: (el: T, index: number) => any) {
+  Array.prototype.forEach.call(els, fn);
+}

--- a/src/ts/helpers/dom.ts
+++ b/src/ts/helpers/dom.ts
@@ -66,3 +66,18 @@ export function forEachNodeList<T extends Node>(list: NodeListOf<T>, fn: {(el: T
     fn(list.item(i), i);
   }
 }
+
+/**
+ * Helper to recousivly find parent with `className`
+ * @param base `Element` to start from
+ * @param className class that the parent should have
+ */
+export function findParentByClassName(base: Element, className: string) {
+  if (base.parentElement === undefined) {
+    return undefined;
+  }
+  if (base.parentElement.classList.contains(className)) {
+    return base.parentElement;
+  }
+  return findParentByClassName(base.parentElement, className);
+};

--- a/src/ts/helpers/dom.ts
+++ b/src/ts/helpers/dom.ts
@@ -32,6 +32,21 @@ export function removeClass<T extends Element>(el: T, className: string): T {
 }
 
 /**
+ * Helper to recursively find parent with the `className` class
+ * @param base `Element` to start from
+ * @param className class that the parent should have
+ */
+export function getParentByClassName(base: Element, className: string) {
+  if (base.parentElement === undefined) {
+    return undefined;
+  }
+  if (base.parentElement.classList.contains(className)) {
+    return base.parentElement;
+  }
+  return getParentByClassName(base.parentElement, className);
+};
+
+/**
  * Removes all child DOM nodes from `el`
  * @param  {Element} el
  */
@@ -66,18 +81,3 @@ export function forEachNodeList<T extends Node>(list: NodeListOf<T>, fn: {(el: T
     fn(list.item(i), i);
   }
 }
-
-/**
- * Helper to recousivly find parent with `className`
- * @param base `Element` to start from
- * @param className class that the parent should have
- */
-export function findParentByClassName(base: Element, className: string) {
-  if (base.parentElement === undefined) {
-    return undefined;
-  }
-  if (base.parentElement.classList.contains(className)) {
-    return base.parentElement;
-  }
-  return findParentByClassName(base.parentElement, className);
-};

--- a/src/ts/helpers/dom.ts
+++ b/src/ts/helpers/dom.ts
@@ -41,3 +41,28 @@ export function removeChildren<T extends Element>(el: T): T {
   }
   return el;
 }
+
+/**
+ * Get last element of `NodeList`
+ * @param list NodeListOf e.g. return value of `getElementsByClassName`
+ */
+export function getLastItemOfNodeList<T extends Node>(list: NodeListOf<T>) {
+  if (!list || list.length === 0) {
+    return undefined;
+  }
+  return list.item(list.length - 1);
+}
+
+/**
+ * Helper to make `NodeListOf` iterable
+ * @param list NodeListOf e.g. return value of `getElementsByClassName`
+ * @param fn Function called for
+ */
+export function forEachNodeList<T extends Node>(list: NodeListOf<T>, fn: {(el: T, index: number): void}): void {
+  if (!list || list.length === 0) {
+    return undefined;
+  }
+  for (let i = 0, len = list.length; i < len; i ++) {
+    fn(list.item(i), i);
+  }
+}

--- a/src/ts/helpers/dom.ts
+++ b/src/ts/helpers/dom.ts
@@ -67,17 +67,3 @@ export function getLastItemOfNodeList<T extends Node>(list: NodeListOf<T>) {
   }
   return list.item(list.length - 1);
 }
-
-/**
- * Helper to make `NodeListOf` iterable
- * @param list NodeListOf e.g. return value of `getElementsByClassName`
- * @param fn Function called for
- */
-export function forEachNodeList<T extends Node>(list: NodeListOf<T>, fn: {(el: T, index: number): void}): void {
-  if (!list || list.length === 0) {
-    return undefined;
-  }
-  for (let i = 0, len = list.length; i < len; i ++) {
-    fn(list.item(i), i);
-  }
-}

--- a/src/ts/helpers/misc.ts
+++ b/src/ts/helpers/misc.ts
@@ -27,7 +27,6 @@ export function contains<T>(arr: T[], item: T): boolean {
   return arr.some((x) => x === item);
 }
 
-
 /**
  * Returns Index of first match to `predicate` in `arr`
  * @param arr Array to search

--- a/src/ts/helpers/misc.ts
+++ b/src/ts/helpers/misc.ts
@@ -27,6 +27,42 @@ export function contains<T>(arr: T[], item: T): boolean {
   return arr.some((x) => x === item);
 }
 
+
+/**
+ * Returns Index of first match to `predicate` in `arr`
+ * @param arr Array to search
+ * @param predicate Function that returns true for a match
+ */
+export function findIndex<T>(arr: T[], predicate: {(el: T, index: number): Boolean}) {
+  let i = 0;
+  if (!arr || arr.length < 1) {
+    return undefined;
+  }
+  const len = arr.length;
+  while (i < len) {
+    if (predicate(arr[i], i)) {
+      return i;
+    }
+    i++;
+  }
+
+  // 7. Return undefined.
+  return undefined;
+}
+
+/**
+ * Returns first match to `predicate` in `arr`
+ * @param arr Array to search
+ * @param predicate Function that returns true for a match
+ */
+export function find<T>(arr: T[], predicate: {(el: T, index: number): Boolean}) {
+  const index = findIndex(arr, predicate);
+  if (index === undefined) {
+    return undefined;
+  }
+  return arr[index];
+}
+
 /**
  * Formats and shortens a url for ui
  * @param  {string} url
@@ -94,4 +130,20 @@ export function toCssClass(seed: string) {
  */
 export function pluralize(word: string, count: number) {
   return word + (count > 1 ? "s" : "");
+}
+
+/**
+ * Check if event is `tab` + `shift` key, to move to previous input element
+ * @param {KeyboardEvent} evt Keyboard event
+ */
+export function isTabUp(evt: KeyboardEvent) {
+  return evt.which === 9 && evt.shiftKey;
+}
+
+/**
+ * Check if event is only `tab` key, to move to next input element
+ * @param {KeyboardEvent} evt Keyboard event
+ */
+export function isTabDown(evt: KeyboardEvent) {
+  return evt.which === 9 && !evt.shiftKey;
 }

--- a/src/ts/helpers/misc.ts
+++ b/src/ts/helpers/misc.ts
@@ -45,8 +45,6 @@ export function findIndex<T>(arr: T[], predicate: {(el: T, index: number): Boole
     }
     i++;
   }
-
-  // 7. Return undefined.
   return undefined;
 }
 

--- a/src/ts/helpers/svg.ts
+++ b/src/ts/helpers/svg.ts
@@ -132,7 +132,7 @@ let getTestSVGEl = (() => {
     clearTimeout(removeSvgTestElTimeout);
     removeSvgTestElTimeout = setTimeout(() => {
       svgTestEl.parentNode.removeChild(svgTestEl);
-    }, 1000);
+    }, 500);
 
     return svgTestEl;
   };
@@ -146,15 +146,17 @@ let getTestSVGEl = (() => {
  */
 export function getNodeTextWidth(textNode: SVGTextElement, skipClone: boolean = false): number {
   let tmp = getTestSVGEl();
-  let tmpTextNode;
+  let tmpTextNode: SVGTextElement;
   if (skipClone) {
     tmpTextNode = textNode;
   } else {
-    tmpTextNode = textNode.cloneNode(false) as SVGTextElement;
+    tmpTextNode = textNode.cloneNode(true) as SVGTextElement;
+    tmpTextNode.setAttribute("x", "0");
+    tmpTextNode.setAttribute("y", "0");
   }
-  tmp.appendChild(tmpTextNode);
   // make sure to turn of shadow for performance
   tmpTextNode.style.textShadow = "0";
+  tmp.appendChild(tmpTextNode);
   window.document.body.appendChild(tmp);
   return tmpTextNode.getBBox().width;
 }

--- a/src/ts/helpers/svg.ts
+++ b/src/ts/helpers/svg.ts
@@ -147,7 +147,9 @@ let getTestSVGEl = (() => {
 export function getNodeTextWidth(textNode: SVGTextElement, skipClone: boolean = false): number {
   let tmp = getTestSVGEl();
   let tmpTextNode: SVGTextElement;
+  let shadow;
   if (skipClone) {
+    shadow = textNode.style.textShadow;
     tmpTextNode = textNode;
   } else {
     tmpTextNode = textNode.cloneNode(true) as SVGTextElement;
@@ -158,5 +160,9 @@ export function getNodeTextWidth(textNode: SVGTextElement, skipClone: boolean = 
   tmpTextNode.style.textShadow = "0";
   tmp.appendChild(tmpTextNode);
   window.document.body.appendChild(tmp);
-  return tmpTextNode.getBBox().width;
+  const width = tmpTextNode.getBBox().width;
+  if (skipClone && shadow !== undefined) {
+    textNode.style.textShadow = shadow;
+  }
+  return width;
 }

--- a/src/ts/typing/context.ts
+++ b/src/ts/typing/context.ts
@@ -32,13 +32,13 @@ export interface OverlayManagerClass {
 
   /** Opens an overlay - rerenders others  */
   openOverlay: (index: number, y: number, detailsHeight: number, entry: WaterfallEntry,
-    barEls: SVGGElement[]) => void;
+    rowItems: SVGAElement[]) => void;
   /** toggles an overlay - rerenders others  */
   toggleOverlay: (index: number, y: number, detailsHeight: number, entry: WaterfallEntry,
-    barEls: SVGGElement[]) => void;
+    rowItems: SVGAElement[]) => void;
 
   /** closes on overlay - rerenders others internally */
-  closeOverlay: (index: number, detailsHeight: number, barEls: SVGGElement[]) => void;
+  closeOverlay: (index: number, detailsHeight: number, rowItems: SVGAElement[]) => void;
 
   // constructor(context: Context, overlayHolder: SVGGElement);
 }

--- a/src/ts/typing/context.ts
+++ b/src/ts/typing/context.ts
@@ -1,6 +1,7 @@
-import {OverlayChangeEvent, OverlayChangeSubscriber} from "./open-overlay";
-import {ChartRenderOption} from "./options";
-import {WaterfallEntry} from "./waterfall";
+import { OverlayManager } from "../waterfall/details-overlay/overlay-manager";
+import { OverlayChangeEvent, OverlayChangeSubscriber } from "./open-overlay";
+import { ChartRenderOption } from "./options";
+import { WaterfallEntry } from "./waterfall";
 
 /**
  * Context object that is passed to (usually stateless) child-functions
@@ -10,7 +11,7 @@ export interface Context {
   /** Publish and Subscribe instance for overlay updates */
   pubSub: PubSubClass;
   /** Overlay (popup) instance manager */
-  overlayManager: OverlayManagerClass;
+  overlayManager: OverlayManager;
   /** horizontal unit (duration in ms of 1%) */
   unit: number;
   /** height of the requests part of the diagram in px */
@@ -21,6 +22,7 @@ export interface Context {
 
 export interface PubSubClass {
   subscribeToOverlayChanges: (fn: OverlayChangeSubscriber) => void;
+  subscribeToSpecificOverlayChanges: (index: number, fn: OverlayChangeSubscriber) => void;
   publishToOverlayChanges: (change: OverlayChangeEvent) => void;
 }
 
@@ -30,10 +32,10 @@ export interface OverlayManagerClass {
 
   /** Opens an overlay - rerenders others  */
   openOverlay: (index: number, y: number, detailsHeight: number, entry: WaterfallEntry,
-                              barEls: SVGGElement[]) => void;
+    barEls: SVGGElement[]) => void;
   /** toggles an overlay - rerenders others  */
   toggleOverlay: (index: number, y: number, detailsHeight: number, entry: WaterfallEntry,
-                              barEls: SVGGElement[]) => void;
+    barEls: SVGGElement[]) => void;
 
   /** closes on overlay - rerenders others internally */
   closeOverlay: (index: number, detailsHeight: number, barEls: SVGGElement[]) => void;

--- a/src/ts/typing/context.ts
+++ b/src/ts/typing/context.ts
@@ -1,7 +1,6 @@
 import { OverlayManager } from "../waterfall/details-overlay/overlay-manager";
-import { OverlayChangeEvent, OverlayChangeSubscriber } from "./open-overlay";
+import { PubSub } from "../waterfall/details-overlay/pub-sub";
 import { ChartRenderOption } from "./options";
-import { WaterfallEntry } from "./waterfall";
 
 /**
  * Context object that is passed to (usually stateless) child-functions
@@ -9,7 +8,7 @@ import { WaterfallEntry } from "./waterfall";
  */
 export interface Context {
   /** Publish and Subscribe instance for overlay updates */
-  pubSub: PubSubClass;
+  pubSub: PubSub;
   /** Overlay (popup) instance manager */
   overlayManager: OverlayManager;
   /** horizontal unit (duration in ms of 1%) */
@@ -18,27 +17,4 @@ export interface Context {
   diagramHeight: number;
   /** Chart config/customization options */
   options: ChartRenderOption;
-}
-
-export interface PubSubClass {
-  subscribeToOverlayChanges: (fn: OverlayChangeSubscriber) => void;
-  subscribeToSpecificOverlayChanges: (index: number, fn: OverlayChangeSubscriber) => void;
-  publishToOverlayChanges: (change: OverlayChangeEvent) => void;
-}
-
-export interface OverlayManagerClass {
-  /** all open overlays height combined */
-  getCombinedOverlayHeight: () => number;
-
-  /** Opens an overlay - rerenders others  */
-  openOverlay: (index: number, y: number, detailsHeight: number, entry: WaterfallEntry,
-    rowItems: SVGAElement[]) => void;
-  /** toggles an overlay - rerenders others  */
-  toggleOverlay: (index: number, y: number, detailsHeight: number, entry: WaterfallEntry,
-    rowItems: SVGAElement[]) => void;
-
-  /** closes on overlay - rerenders others internally */
-  closeOverlay: (index: number, detailsHeight: number, rowItems: SVGAElement[]) => void;
-
-  // constructor(context: Context, overlayHolder: SVGGElement);
 }

--- a/src/ts/typing/open-overlay.ts
+++ b/src/ts/typing/open-overlay.ts
@@ -24,6 +24,9 @@ export interface OverlayChangeEvent {
   type: EventType;
   /** list of currenly open overlays */
   openOverlays: OpenOverlay[];
+  /** index that triggerd the change */
+  changedIndex?: number;
+  changedOverlay: OpenOverlay;
   combinedOverlayHeight: number;
 }
 

--- a/src/ts/typing/open-overlay.ts
+++ b/src/ts/typing/open-overlay.ts
@@ -22,11 +22,8 @@ export interface OpenOverlay {
 
 export interface OverlayChangeEvent {
   type: EventType;
-  /** list of currenly open overlays */
-  openOverlays: OpenOverlay[];
   /** index that triggerd the change */
   changedIndex?: number;
-  changedOverlay: OpenOverlay;
   combinedOverlayHeight: number;
 }
 

--- a/src/ts/waterfall/details-overlay/html-details-body.ts
+++ b/src/ts/waterfall/details-overlay/html-details-body.ts
@@ -1,6 +1,14 @@
 import { escapeHtml, sanitizeUrlForLink } from "../../helpers/parse";
 import { WaterfallEntry } from "../../typing/waterfall";
 
+/**
+ * Creates the HTML body for the overlay
+ *
+ * _All tabable elements are set to `tabindex="-1"` to avoid tabing issues_
+ * @param requestID ID
+ * @param detailsHeight
+ * @param entry
+ */
 export function createDetailsBody(requestID: number, detailsHeight: number, entry: WaterfallEntry) {
 
   let html = document.createElement("html") as HTMLHtmlElement;
@@ -33,7 +41,9 @@ export function createDetailsBody(requestID: number, detailsHeight: number, entr
   body.innerHTML = `
     <div class="wrapper">
       <header class="type-${entry.responseDetails.requestType}">
-        <h3><strong>#${requestID}</strong> <a href="${sanitizeUrlForLink(entry.url)}">${escapeHtml(entry.url)}</a></h3>
+        <h3><strong>#${requestID}</strong> <a href="${sanitizeUrlForLink(entry.url)}">
+          ${escapeHtml(entry.url)}
+        </a></h3>
         <nav class="tab-nav">
           <ul>
             ${tabMenu}

--- a/src/ts/waterfall/details-overlay/overlay-manager.ts
+++ b/src/ts/waterfall/details-overlay/overlay-manager.ts
@@ -138,7 +138,6 @@ class OverlayManager implements OverlayManagerClass {
     /** shared variable to keep track of heigth */
     let currY = 0;
     let updateHeight = (overlay, y, currHeight) => {
-      // console.log(currY, currHeight);
       currY += currHeight;
       overlay.actualY = y;
       overlay.height = currHeight;
@@ -159,7 +158,7 @@ class OverlayManager implements OverlayManagerClass {
       overlayHolder.appendChild(infoOverlay);
       updateHeight(overlay, y, infoOverlay.getBoundingClientRect().height);
     };
-    rowItems.forEach((rowItem, index) => {
+    let updateRow = (rowItem, index) => {
       const overlay = find(this.openOverlays, (o) => o.index === index);
       const overlayEl = rowItem.nextElementSibling.firstElementChild as SVGGElement;
       this.realignRow(rowItem, currY);
@@ -176,15 +175,24 @@ class OverlayManager implements OverlayManagerClass {
         return; // not open
       }
       if (overlayEl) {
-        updateHeight(overlay, overlay.defaultY + currY, overlay.height);
-        const fo = overlayEl.querySelector("foreignObject");
         const bg = overlayEl.querySelector(".info-overlay-bg");
-        fo.setAttribute("y", overlay.actualY.toString());
+        const fo = overlayEl.querySelector("foreignObject");
+        const btnRect = overlayEl.querySelector(".info-overlay-close-btn rect");
+        const btnText = overlayEl.querySelector(".info-overlay-close-btn text");
+        // bg.setAttribute("transform", `translate(0, ${currY})`);
+        // btnText.setAttribute("transform", `translate(0, ${currY})`);
+        // btnRect.setAttribute("transform", `translate(0, ${currY})`);
+        updateHeight(overlay, overlay.defaultY + currY, overlay.height);
+        // needs updateHeight
         bg.setAttribute("y", overlay.actualY.toString());
+        fo.setAttribute("y", overlay.actualY.toString());
+        btnText.setAttribute("y", overlay.actualY.toString());
+        btnRect.setAttribute("y", overlay.actualY.toString());
         return;
       }
       addNewOverlay(rowItem.nextElementSibling as SVGGElement, overlay);
-    });
+    };
+    rowItems.forEach(updateRow);
   }
 };
 export {

--- a/src/ts/waterfall/details-overlay/overlay-manager.ts
+++ b/src/ts/waterfall/details-overlay/overlay-manager.ts
@@ -80,9 +80,7 @@ class OverlayManager {
     this.renderOverlays(detailsHeight, rowItems);
     this.context.pubSub.publishToOverlayChanges({
       "changedIndex": index,
-      "changedOverlay": newOverlay,
       "combinedOverlayHeight": self.getCombinedOverlayHeight(),
-      "openOverlays": self.openOverlays,
       "type": "open",
     } as OverlayChangeEvent);
   }
@@ -112,7 +110,6 @@ class OverlayManager {
     this.context.pubSub.publishToOverlayChanges({
       "changedIndex": index,
       "combinedOverlayHeight": self.getCombinedOverlayHeight(),
-      "openOverlays": self.openOverlays,
       "type": "closed",
     } as OverlayChangeEvent);
   }
@@ -158,7 +155,7 @@ class OverlayManager {
       overlayHolder.appendChild(infoOverlay);
       updateHeight(overlay, y, infoOverlay.getBoundingClientRect().height);
     };
-    let updateRow = (rowItem, index) => {
+    let updateRow = (rowItem: SVGAElement, index: number) => {
       const overlay = find(this.openOverlays, (o) => o.index === index);
       const overlayEl = rowItem.nextElementSibling.firstElementChild as SVGGElement;
       this.realignRow(rowItem, currY);

--- a/src/ts/waterfall/details-overlay/overlay-manager.ts
+++ b/src/ts/waterfall/details-overlay/overlay-manager.ts
@@ -179,9 +179,6 @@ class OverlayManager implements OverlayManagerClass {
         const fo = overlayEl.querySelector("foreignObject");
         const btnRect = overlayEl.querySelector(".info-overlay-close-btn rect");
         const btnText = overlayEl.querySelector(".info-overlay-close-btn text");
-        // bg.setAttribute("transform", `translate(0, ${currY})`);
-        // btnText.setAttribute("transform", `translate(0, ${currY})`);
-        // btnRect.setAttribute("transform", `translate(0, ${currY})`);
         updateHeight(overlay, overlay.defaultY + currY, overlay.height);
         // needs updateHeight
         bg.setAttribute("y", overlay.actualY.toString());

--- a/src/ts/waterfall/details-overlay/overlay-manager.ts
+++ b/src/ts/waterfall/details-overlay/overlay-manager.ts
@@ -5,7 +5,7 @@ import { WaterfallEntry } from "../../typing/waterfall";
 import { createRowInfoOverlay } from "./svg-details-overlay";
 
 /** Overlay (popup) instance manager */
-export default class OverlayManager implements OverlayManagerClass {
+class OverlayManager implements OverlayManagerClass {
   /** Collection of currely open overlays */
   private openOverlays: OpenOverlay[] = [];
 
@@ -19,6 +19,10 @@ export default class OverlayManager implements OverlayManagerClass {
     return this.openOverlays.reduce((pre, curr) => pre + curr.height, 0);
   }
 
+  public getOpenOverlays() {
+    return this.openOverlays;
+  }
+
   /**
    * Opens an overlay - rerenders others internaly
    */
@@ -28,8 +32,7 @@ export default class OverlayManager implements OverlayManagerClass {
       return;
     }
     const self = this;
-
-    this.openOverlays.push({
+    const newOverlay: OpenOverlay = {
       "defaultY": y,
       "entry": entry,
       "index": index,
@@ -37,10 +40,13 @@ export default class OverlayManager implements OverlayManagerClass {
         self.closeOverlay(index, detailsHeight, barEls);
       },
       "openTabIndex": 0,
-    });
+    };
+    this.openOverlays.push(newOverlay);
 
     this.renderOverlays(detailsHeight);
     this.context.pubSub.publishToOverlayChanges({
+      "changedIndex": index,
+      "changedOverlay": newOverlay,
       "combinedOverlayHeight": self.getCombinedOverlayHeight(),
       "openOverlays": self.openOverlays,
       "type": "open",
@@ -71,6 +77,7 @@ export default class OverlayManager implements OverlayManagerClass {
 
     this.renderOverlays(detailsHeight);
     this.context.pubSub.publishToOverlayChanges({
+      "changedIndex": index,
       "combinedOverlayHeight": self.getCombinedOverlayHeight(),
       "openOverlays": self.openOverlays,
       "type": "closed",
@@ -131,3 +138,7 @@ export default class OverlayManager implements OverlayManagerClass {
       });
   }
 };
+export {
+  OverlayManager
+};
+export default OverlayManager;

--- a/src/ts/waterfall/details-overlay/overlay-manager.ts
+++ b/src/ts/waterfall/details-overlay/overlay-manager.ts
@@ -8,13 +8,13 @@ import {
   isTabDown,
   isTabUp,
 } from "../../helpers/misc";
-import { Context, OverlayManagerClass } from "../../typing/context";
+import { Context } from "../../typing/context";
 import { OpenOverlay, OverlayChangeEvent } from "../../typing/open-overlay";
 import { WaterfallEntry } from "../../typing/waterfall";
 import { createRowInfoOverlay } from "./svg-details-overlay";
 
 /** Overlay (popup) instance manager */
-class OverlayManager implements OverlayManagerClass {
+class OverlayManager {
   private static showFullName = (el: Element) => {
     el.getElementsByClassName("row-fixed").item(0)
       .dispatchEvent(new MouseEvent("mouseenter"));
@@ -192,6 +192,7 @@ class OverlayManager implements OverlayManagerClass {
     rowItems.forEach(updateRow);
   }
 };
+
 export {
   OverlayManager
 };

--- a/src/ts/waterfall/details-overlay/pub-sub.ts
+++ b/src/ts/waterfall/details-overlay/pub-sub.ts
@@ -1,12 +1,20 @@
 // simple pub/sub for change to the overlay
-import {PubSubClass} from "../../typing/context";
-import {OverlayChangeEvent, OverlayChangeSubscriber} from "../../typing/open-overlay";
+import { PubSubClass } from "../../typing/context";
+import { OverlayChangeEvent, OverlayChangeSubscriber } from "../../typing/open-overlay";
 
 export default class PubSub implements PubSubClass {
   private subscribers: OverlayChangeSubscriber[] = [];
 
   public subscribeToOverlayChanges(fn: OverlayChangeSubscriber) {
     this.subscribers.push(fn);
+  }
+
+  public subscribeToSpecificOverlayChanges(index: number, fn: OverlayChangeSubscriber) {
+    this.subscribers.push((evt) => {
+      if (evt.changedIndex === index) {
+        fn(evt);
+      }
+    });
   }
 
   public publishToOverlayChanges(change: OverlayChangeEvent) {

--- a/src/ts/waterfall/details-overlay/pub-sub.ts
+++ b/src/ts/waterfall/details-overlay/pub-sub.ts
@@ -1,14 +1,18 @@
 // simple pub/sub for change to the overlay
-import { PubSubClass } from "../../typing/context";
 import { OverlayChangeEvent, OverlayChangeSubscriber } from "../../typing/open-overlay";
 
-export default class PubSub implements PubSubClass {
+class PubSub {
   private subscribers: OverlayChangeSubscriber[] = [];
 
+  /** Call `fn` whenever a new change is publisched on OverlayChanges channel */
   public subscribeToOverlayChanges(fn: OverlayChangeSubscriber) {
     this.subscribers.push(fn);
   }
 
+  /**
+   * Call `fn` whenever a new change for `index` are publisched
+   * on OverlayChanges channel
+   */
   public subscribeToSpecificOverlayChanges(index: number, fn: OverlayChangeSubscriber) {
     this.subscribers.push((evt) => {
       if (evt.changedIndex === index) {
@@ -17,7 +21,13 @@ export default class PubSub implements PubSubClass {
     });
   }
 
+  /** Publish a change on OverlayChanges channel  */
   public publishToOverlayChanges(change: OverlayChangeEvent) {
     this.subscribers.forEach((fn) => fn(change));
   }
 };
+
+export {
+  PubSub
+}
+export default PubSub;

--- a/src/ts/waterfall/details-overlay/svg-details-overlay.ts
+++ b/src/ts/waterfall/details-overlay/svg-details-overlay.ts
@@ -47,7 +47,7 @@ function createHolder(y: number, detailsHeight: number) {
 
 export function createRowInfoOverlay(overlay: OpenOverlay, y: number, detailsHeight: number): SVGGElement {
   const requestID = overlay.index + 1;
-  let wrapper = svg.newG("outer-info-overlay-holder");
+  let wrapper = svg.newG(`outer-info-overlay-holder overlay-index-${overlay.index}`);
   let holder = createHolder(y, detailsHeight);
 
   let foreignObject = svg.newForeignObject({

--- a/src/ts/waterfall/details-overlay/svg-details-overlay.ts
+++ b/src/ts/waterfall/details-overlay/svg-details-overlay.ts
@@ -1,10 +1,7 @@
+import { forEachNodeList } from "../../helpers/dom";
 import * as svg from "../../helpers/svg";
 import { OpenOverlay } from "../../typing/open-overlay";
 import { createDetailsBody } from "./html-details-body";
-
-export function forEach(els: NodeListOf<Element>, fn: (el: Element, index: number) => any) {
-  Array.prototype.forEach.call(els, fn);
-}
 
 function createCloseButtonSvg(y: number): SVGGElement {
   let closeBtn = svg.newA("info-overlay-close-btn");
@@ -63,13 +60,13 @@ export function createRowInfoOverlay(overlay: OpenOverlay, y: number, detailsHei
 
   let setTabStatus = (tabIndex: number) => {
     overlay.openTabIndex = tabIndex;
-    forEach(tabs, (tab: HTMLDivElement, j) => {
+    forEachNodeList(tabs, (tab: HTMLDivElement, j) => {
       tab.style.display = (tabIndex === j) ? "block" : "none";
       buttons.item(j).classList.toggle("active", (tabIndex === j));
     });
   };
 
-  forEach(buttons, (btn, tabIndex) => {
+  forEachNodeList(buttons, (btn, tabIndex) => {
     btn.addEventListener("click", () => setTabStatus(tabIndex));
   });
 

--- a/src/ts/waterfall/details-overlay/svg-details-overlay.ts
+++ b/src/ts/waterfall/details-overlay/svg-details-overlay.ts
@@ -29,9 +29,7 @@ function createCloseButtonSvg(y: number): SVGGElement {
 }
 
 function createHolder(y: number, detailsHeight: number) {
-
-  let innerHolder = svg.newG("info-overlay-holder");
-
+  let holder = svg.newG("info-overlay-holder");
   let bg = svg.newRect({
     "height": detailsHeight,
     "rx": 2,
@@ -39,15 +37,14 @@ function createHolder(y: number, detailsHeight: number) {
     "width": "100%",
     "x": "0",
     "y": y,
-  }, "info-overlay");
+  }, "info-overlay-bg");
 
-  innerHolder.appendChild(bg);
-  return innerHolder;
+  holder.appendChild(bg);
+  return holder;
 }
 
 export function createRowInfoOverlay(overlay: OpenOverlay, y: number, detailsHeight: number): SVGGElement {
   const requestID = overlay.index + 1;
-  let wrapper = svg.newG(`outer-info-overlay-holder overlay-index-${overlay.index}`);
   let holder = createHolder(y, detailsHeight);
 
   let foreignObject = svg.newForeignObject({
@@ -82,7 +79,5 @@ export function createRowInfoOverlay(overlay: OpenOverlay, y: number, detailsHei
   holder.appendChild(foreignObject);
   holder.appendChild(closeBtn);
 
-  wrapper.appendChild(holder);
-
-  return wrapper;
+  return holder;
 }

--- a/src/ts/waterfall/row/svg-row-subcomponents.ts
+++ b/src/ts/waterfall/row/svg-row-subcomponents.ts
@@ -223,8 +223,7 @@ export function createBgStripe(y: number, height: number, isEven: boolean): SVGR
   }, className);
 }
 
-export function createNameRowBg(y: number, rowHeight: number,
-                                onClick: EventListener): SVGGElement {
+export function createNameRowBg(y: number, rowHeight: number): SVGGElement {
   let rowFixed = svg.newG("row row-fixed");
 
   rowFixed.appendChild(svg.newRect({
@@ -237,12 +236,10 @@ export function createNameRowBg(y: number, rowHeight: number,
       "opacity": 0,
     }));
 
-  rowFixed.addEventListener("click", onClick);
-
   return rowFixed;
 }
 
-export function createRowBg(y: number, rowHeight: number, onClick: EventListener): SVGGElement {
+export function createRowBg(y: number, rowHeight: number): SVGGElement {
   let rowFixed = svg.newG("row row-flex");
 
   rowFixed.appendChild(svg.newRect({
@@ -254,8 +251,6 @@ export function createRowBg(y: number, rowHeight: number, onClick: EventListener
     {
       "opacity": 0,
     }));
-
-  rowFixed.addEventListener("click", onClick);
 
   return rowFixed;
 }

--- a/src/ts/waterfall/row/svg-row-subcomponents.ts
+++ b/src/ts/waterfall/row/svg-row-subcomponents.ts
@@ -4,9 +4,9 @@
 
 import * as misc from "../../helpers/misc";
 import * as svg from "../../helpers/svg";
-import {timingTypeToCssClass} from "../../transformers/styling-converters";
-import {RectData} from "../../typing/rect-data";
-import {WaterfallEntryTiming} from "../../typing/waterfall";
+import { timingTypeToCssClass } from "../../transformers/styling-converters";
+import { RectData } from "../../typing/rect-data";
+import { WaterfallEntryTiming } from "../../typing/waterfall";
 
 /**
  * Creates the `rect` that represent the timings in `rectData`
@@ -148,12 +148,16 @@ export function createRequestLabelClipped(x: number, y: number, name: string, he
  */
 export function createRequestLabelFull(x: number, y: number, name: string, height: number) {
   let blockLabel = createRequestLabel(x, y, name, height);
-  let labelHolder = svg.newG("full-label");
+  let labelHolder = svg.newG("full-label", {}, {
+    clipPath: `url(#titleFullClipPath)`,
+  });
   labelHolder.appendChild(svg.newRect({
     "height": height - 4,
     "rx": 5,
     "ry": 5,
-    "width": svg.getNodeTextWidth(blockLabel),
+    // for initial load performance use 500px as base width
+    // it's updated one by one on hover
+    "width": 500,
     "x": x - 3,
     "y": y + 3,
   }, "label-full-bg"));
@@ -168,11 +172,13 @@ function createRequestLabel(x: number, y: number, name: string, height: number):
   let blockLabel = svg.newTextEl(blockName, {x, y});
 
   blockLabel.appendChild(svg.newTitle(name));
-
   blockLabel.style.opacity = name.match(/js.map$/) ? "0.5" : "1";
 
   return blockLabel;
 }
+
+const supportsAnimationFrame = (typeof window.requestAnimationFrame === "function" &&
+  typeof window.cancelAnimationFrame === "function");
 
 /**
  * Appends the labels to `rowFixed` - TODO: see if this can be done more elegant
@@ -192,17 +198,38 @@ export function appendRequestLabels(rowFixed: SVGGElement, requestNumberLabel: S
   rowFixed.appendChild(requestNumberLabel);
   rowFixed.appendChild(shortLabel);
   rowFixed.appendChild(fullLabel);
-
+  /** the size adjustment only needs to happend once, this var keeps track of that */
+  let isAdjusted = false;
+  /** store AnimationFrame id, to cancel it if hovering was too fast */
+  let updateAnimFrame: number;
   rowFixed.addEventListener("mouseenter", () => {
     fullLabel.style.display = "block";
     shortLabel.style.display = "none";
     fullLabel.style.visibility = "visible";
-    labelFullBg.style.width = (fullLabelText.clientWidth + 10).toString();
+
+    // offload doublecheck of width
+    const update = () => {
+      const newWidth = fullLabelText.getBBox().width + 10;
+      labelFullBg.setAttribute("width", newWidth.toString());
+      isAdjusted = true;
+      updateAnimFrame = undefined;
+    };
+
+    if (!isAdjusted) {
+      if (supportsAnimationFrame) {
+        updateAnimFrame = window.requestAnimationFrame(update);
+      } else {
+        update();
+      }
+    }
   });
   rowFixed.addEventListener("mouseleave", () => {
     shortLabel.style.display = "block";
     fullLabel.style.display = "none";
     fullLabel.style.visibility = "hidden";
+    if (supportsAnimationFrame && updateAnimFrame !== undefined) {
+      cancelAnimationFrame(updateAnimFrame);
+    }
   });
 }
 

--- a/src/ts/waterfall/row/svg-row.ts
+++ b/src/ts/waterfall/row/svg-row.ts
@@ -19,6 +19,12 @@ clipPathElProto.appendChild(svg.newRect({
   "width": "100%",
 }));
 
+const clipPathElFullProto = svg.newClipPath("titleFullClipPath");
+clipPathElFullProto.appendChild(svg.newRect({
+  "height": "100%",
+  "width": "100%",
+}));
+
 const ROW_LEFT_MARGIN = 3;
 
 // Create row for a single request
@@ -93,6 +99,7 @@ export function createRow(context: Context, index: number,
   let hasPrevOpenOverlay: boolean;
 
   rowItem.addEventListener("click", (evt: MouseEvent) => {
+    evt.preventDefault();
     onDetailsOverlayShow(evt);
   });
   rowItem.addEventListener("keydown", (evt: KeyboardEvent) => {
@@ -123,6 +130,7 @@ export function createRow(context: Context, index: number,
   leftFixedHolder.appendChild(clipPathElProto.cloneNode(true));
   leftFixedHolder.appendChild(rowName);
 
+  rowItem.appendChild(clipPathElFullProto.cloneNode(true));
   rowItem.appendChild(bgStripe);
   rowItem.appendChild(flexScaleHolder);
   rowItem.appendChild(leftFixedHolder);

--- a/src/ts/waterfall/row/svg-row.ts
+++ b/src/ts/waterfall/row/svg-row.ts
@@ -1,4 +1,3 @@
-// import { getLastItemOfNodeList } from "../../helpers/dom";
 import * as icons from "../../helpers/icons";
 import {
   isTabDown,

--- a/src/ts/waterfall/row/svg-row.ts
+++ b/src/ts/waterfall/row/svg-row.ts
@@ -7,7 +7,6 @@ import {
 } from "../../helpers/misc";
 import * as svg from "../../helpers/svg";
 import { Context } from "../../typing/context";
-import { OpenOverlay } from "../../typing/open-overlay";
 import { RectData } from "../../typing/rect-data";
 import { WaterfallEntry } from "../../typing/waterfall";
 import { getIndicatorIcons } from "./svg-indicators";
@@ -80,195 +79,43 @@ export function createRow(context: Context, index: number,
 
   rowSubComponents.appendRequestLabels(rowName, requestNumberLabel, shortLabel, fullLabel);
 
-  // const onOpenOverlayFocusOut = (evt: KeyboardEvent) => {
-  //   if (evt.which !== 9) {
-  //     return; // only handle tabs
-  //   }
-  //   const isUpward = evt.shiftKey;
-  //   console.log("onActiveFocusOut", isUpward);
-  // };
-
-  // accordeon a11y guide
-  // https://www.w3.org/TR/wai-aria-practices-1.1/#accordion
   context.pubSub.subscribeToSpecificOverlayChanges(index, (change) => {
-    openOverlay = (change.type === "open") ? change.changedOverlay : undefined;
+    hasOpenOverlay = (change.type === "open");
   });
   if (index > 0) {
     context.pubSub.subscribeToSpecificOverlayChanges(index - 1, (change) => {
-      prevOpenOverlay = (change.type === "open") ? change.changedOverlay : undefined;
+      hasPrevOpenOverlay = (change.type === "open");
     });
   }
 
-  let isPoinerClick = false;
-  let openOverlay: OpenOverlay;
-  /** Poiter to the previous open Oberlay (if exist) */
-  let prevOpenOverlay: OpenOverlay;
-  // let showDetailsTimeout: number;
+  let hasOpenOverlay: boolean;
+  let hasPrevOpenOverlay: boolean;
 
-
-
-  // const enterOverlaySetup = (isDownwards: boolean, openOverlay: OpenOverlay) => {
-  //   const overlayEl = context.overlayManager.getOpenOverlayDomEl(openOverlay);
-  //   /** Top header el */
-  //   const firstFocusEl = overlayEl.getElementsByTagName("a")[0];
-  //   /** All focusable elements */
-  //   const allFocusEl = overlayEl.querySelectorAll(":scope a, :scope button");
-  //   const lastTab = getLastItemOfNodeList(allFocusEl);
-  //   for (let i = allFocusEl.length - 1; i <= 0 i--) {
-  //     const el = allFocusEl.item(i);
-  //     el.setAttribute("tabindex", "0");
-  //   }
-  //   console.log(allFocusEl)
-
-  //   const onOverlayExit = () => {
-  //     console.log("Implement me");
-  //     for (let i = allFocusEl.length - 1; i <= 0 i--) {
-  //       const el = allFocusEl.item(i);
-  //       el.setAttribute("tabindex", "-1");
-  //     }
-  //     lastTab.removeEventListener("keypress", onLastElKeypress);
-  //   };
-
-  //   const onLastElKeypress = (evt: KeyboardEvent) => {
-  //     if (isTabDown(evt)) {
-  //       evt.preventDefault();
-  //       onOverlayExit();
-  //     }
-  //   };
-  //   lastTab.addEventListener("keypress", onLastElKeypress)
-  //   firstFocusEl.focus();
-  // };
-
-
-
-
-  // triggered before click by touch and mouse devices
-  rowItem.addEventListener("mouseup", () => {
-    isPoinerClick = true;
-  });
   rowItem.addEventListener("click", (evt: MouseEvent) => {
-    isPoinerClick = false;
     onDetailsOverlayShow(evt);
   });
   rowItem.addEventListener("keydown", (evt: KeyboardEvent) => {
     // on enter
     if (evt.which === 32) {
-      evt.preventDefault();
-      onDetailsOverlayShow(evt);
-      return;
+      return onDetailsOverlayShow(evt);
     }
 
-    // // moving down into overlay
-    // if (isTabDown(evt) && openOverlay) {
-    //   console.log("moving down into overlay");
-    //   evt.preventDefault();
-    //   const overlayEl = context.overlayManager.getOpenOverlayDomEl(openOverlay);
-    //   /** Top header el */
-    //   const firstFocusEl = overlayEl.getElementsByTagName("a")[0];
-    //   const lastTab = getLastItemOfNodeList(overlayEl.getElementsByClassName("tab-button") as
-    //     NodeListOf<HTMLButtonElement>);
-
-    //   // Move out up the the top, to the node el
-    //   firstFocusEl.addEventListener("keydown", (inOverlayEvt: KeyboardEvent) => {
-    //     // IE & Edge do not support `focus()` in SVG
-    //     if (isTabUp(inOverlayEvt) && typeof (rowItem as any).focus === "function") {
-    //       console.log("Move out up the the top, to the node el");
-    //       inOverlayEvt.preventDefault();
-    //       console.log("rowItem in `nextFocusEl.on keydown with tab+shift`", rowItem);
-    //       (rowItem as any).focus();
-    //     }
-    //   });
-
-    //   console.log("lastTab", lastTab);
-    //   // Move out down at the end
-    //   lastTab.addEventListener("keydown", (inOverlayEvt: KeyboardEvent) => {
-    //     // IE & Edge do not support `focus()` in SVG
-    //     if (isTabDown(inOverlayEvt) && typeof (rowItem as any).focus === "function") {
-    //       console.log("Move out down at the end");
-    //       if (rowItem.nextSibling) {
-    //         inOverlayEvt.preventDefault();
-    //         // not last in chart
-    //         (rowItem.nextSibling as any).focus();
-    //       } else {
-    //         //last in chart
-    //         console.log("last in chart")
-    //         inOverlayEvt.preventDefault();
-    //       }
-    //     } else if (isTabDown(inOverlayEvt)) {
-    //       console.log(">>>");
-    //     }
-    //   });
-    //   firstFocusEl.focus();
-    //   return;
-    //   // evt.cancelBubble = true;
-    // }
-
-    // // moving up into overlay
-    // if (isTabUp(evt) && prevOpenOverlay) {
-    //   console.log("moving up into overlay");
-    //   evt.preventDefault();
-    //   const prevOverlayEl = context.overlayManager.getOpenOverlayDomEl(prevOpenOverlay);
-    //   const lastTab = getLastItemOfNodeList(prevOverlayEl.getElementsByClassName("tab-button") as
-    //     NodeListOf<HTMLButtonElement>);
-    //   lastTab.focus();
-    //   return;
-    // }
-
-    // // tab without open overlays around
-    if (isTabUp(evt) && !prevOpenOverlay && index > 0) {
+    // tab without open overlays around
+    if (isTabUp(evt) && !hasPrevOpenOverlay && index > 0) {
       rowItem.previousSibling.previousSibling.lastChild.lastChild.dispatchEvent(new MouseEvent("mouseenter"));
       return;
     }
-    if (isTabDown(evt) && !openOverlay) {
+    if (isTabDown(evt) && !hasOpenOverlay) {
       if (rowItem.nextSibling && rowItem.nextSibling.nextSibling) {
         rowItem.nextSibling.nextSibling.lastChild.lastChild.dispatchEvent(new MouseEvent("mouseenter"));
       }
-    // else {
-    //     console.log("Sort this out > tab without open overlays around");
-    //     if (context.overlayManager.hasOpenOverlays()) {
-    //       const lastTab = getLastItemOfNodeList(context.overlayManager.getLastOpenOverlayDomEl()
-    //         .getElementsByClassName("tab-button") as NodeListOf<HTMLButtonElement>);
-    //       console.log("END", lastTab);
-    //       lastTab.focus();
-    //     }
-    //     // prev
-    //     // do not prevent default, so the focus moves on
-    // }
       return;
     }
-    // // Not handled
-    // if (evt.which === 9) {
-    //   console.log("go to next/prev thing");
-    // }
   });
-
-  // rowItem.addEventListener("keyup", (evt: KeyboardEvent) => {
-  //   if (evt.which === 9) {
-  //     //document.activeElement === rowItem
-  //     console.log("keydown");
-  //     rowName.dispatchEvent(new MouseEvent("mouseenter"));
-  //     window["eventsStore"]["key"].push(evt);
-  //   }
-  // });
-
-
-  // rowItem.addEventListener("focusin", (evt: FocusEvent) => {
-  //   console.log("in", isPoinerClick);
-  //   // const test = new MouseEvent("mouseenter");
-  //   rowName.dispatchEvent(new MouseEvent("mouseenter"));
-  //   window["eventsStore"]["mouse"].push(evt);
-  // });
-
 
   rowItem.addEventListener("focusout", () => {
     rowName.dispatchEvent(new MouseEvent("mouseleave"));
   });
-
-  // rowItem.addEventListener("click", (evt) => {
-  //   console.log("click", evt);
-  //   onDetailsOverlayShow(evt);
-  // });
-
 
   flexScaleHolder.appendChild(rowBar);
   leftFixedHolder.appendChild(clipPathElProto.cloneNode(true));

--- a/src/ts/waterfall/row/svg-row.ts
+++ b/src/ts/waterfall/row/svg-row.ts
@@ -31,7 +31,8 @@ export function createRow(context: Context, index: number,
   const rowHeight = rectData.height;
   const leftColumnWith = context.options.leftColumnWith;
   let rowItem = svg.newA(entry.responseDetails.rowClass);
-  rowItem.setAttribute("href", "javascript:void(0)");
+  rowItem.setAttribute("tabindex", "0");
+  rowItem.setAttribute("xlink:href", "javascript:void(0)");
   let leftFixedHolder = svg.newSvg("left-fixed-holder", {
     "width": `${leftColumnWith}%`,
     "x": "0",
@@ -95,8 +96,9 @@ export function createRow(context: Context, index: number,
     onDetailsOverlayShow(evt);
   });
   rowItem.addEventListener("keydown", (evt: KeyboardEvent) => {
-    // on enter
-    if (evt.which === 32) {
+    // space on enter
+    if (evt.which === 32 || evt.which === 13) {
+      evt.preventDefault();
       return onDetailsOverlayShow(evt);
     }
 

--- a/src/ts/waterfall/svg-chart.ts
+++ b/src/ts/waterfall/svg-chart.ts
@@ -7,7 +7,7 @@ import {HoverEvtListeners} from "../typing/svg-alignment-helpers";
 import {Mark} from "../typing/waterfall";
 import {WaterfallData, WaterfallEntry} from "../typing/waterfall";
 import OverlayManager from "./details-overlay/overlay-manager";
-import PubSub from "./details-overlay/pub-sub";
+import { PubSub } from "./details-overlay/pub-sub";
 import * as row from "./row/svg-row";
 import * as alignmentHelper from  "./sub-components/svg-alignment-helper";
 import * as generalComponents from "./sub-components/svg-general-components";

--- a/src/ts/waterfall/svg-chart.ts
+++ b/src/ts/waterfall/svg-chart.ts
@@ -51,7 +51,7 @@ function getSvgHeight(marks: Mark[], diagramHeight: number): number {
  * @return {Context} Context object
  */
 function createContext(data: WaterfallData, options: ChartRenderOption,
-                       entriesToShow: WaterfallEntry[], rowHolder: SVGGElement): Context {
+                       entriesToShow: WaterfallEntry[]): Context {
   const unit = data.durationMs / 100;
   const diagramHeight = (entriesToShow.length + 1) * options.rowHeight;
   let context = {
@@ -62,7 +62,7 @@ function createContext(data: WaterfallData, options: ChartRenderOption,
     options,
   };
   // `overlayManager` needs the `context` reference, so it's attached later
-  context.overlayManager = new OverlayManager(context, rowHolder);
+  context.overlayManager = new OverlayManager(context);
 
   return context;
 }
@@ -85,7 +85,7 @@ export function createWaterfallSvg(data: WaterfallData, options: ChartRenderOpti
   /** Holds all rows */
   let rowHolder = svg.newG("rows-holder");
 
-  const context = createContext(data, options, entriesToShow, rowHolder);
+  const context = createContext(data, options, entriesToShow);
 
   /** full height of the SVG chart in px */
   const chartHolderHeight = getSvgHeight(data.marks, context.diagramHeight);

--- a/src/ts/waterfall/svg-chart.ts
+++ b/src/ts/waterfall/svg-chart.ts
@@ -51,10 +51,9 @@ function getSvgHeight(marks: Mark[], diagramHeight: number): number {
  * @return {Context} Context object
  */
 function createContext(data: WaterfallData, options: ChartRenderOption,
-                       entriesToShow: WaterfallEntry[], overlayHolder: SVGGElement): Context {
+                       entriesToShow: WaterfallEntry[], rowHolder: SVGGElement): Context {
   const unit = data.durationMs / 100;
   const diagramHeight = (entriesToShow.length + 1) * options.rowHeight;
-
   let context = {
     diagramHeight,
     overlayManager: undefined,
@@ -63,7 +62,7 @@ function createContext(data: WaterfallData, options: ChartRenderOption,
     options,
   };
   // `overlayManager` needs the `context` reference, so it's attached later
-  context.overlayManager = new OverlayManager(context, overlayHolder);
+  context.overlayManager = new OverlayManager(context, rowHolder);
 
   return context;
 }
@@ -83,7 +82,10 @@ export function createWaterfallSvg(data: WaterfallData, options: ChartRenderOpti
   /** Holder of request-details overlay */
   let overlayHolder = svg.newG("overlays");
 
-  const context = createContext(data, options, entriesToShow, overlayHolder);
+  /** Holds all rows */
+  let rowHolder = svg.newG("rows-holder");
+
+  const context = createContext(data, options, entriesToShow, rowHolder);
 
   /** full height of the SVG chart in px */
   const chartHolderHeight = getSvgHeight(data.marks, context.diagramHeight);
@@ -98,8 +100,6 @@ export function createWaterfallSvg(data: WaterfallData, options: ChartRenderOpti
     "width": `${100 - options.leftColumnWith}%`,
     "x": `${options.leftColumnWith}%`,
   });
-  /** Holds all rows */
-  let rowHolder = svg.newG("rows-holder");
 
   /** Holder for on-hover vertical comparison bars */
   let hoverOverlayHolder: SVGGElement;
@@ -176,6 +176,7 @@ export function createWaterfallSvg(data: WaterfallData, options: ChartRenderOpti
 
     barEls.push(rowItem);
     rowHolder.appendChild(rowItem);
+    rowHolder.appendChild(svg.newG("row-overlay-holder"));
   }
 
   // Main loop to render rows with blocks

--- a/src/ts/waterfall/svg-chart.ts
+++ b/src/ts/waterfall/svg-chart.ts
@@ -137,7 +137,7 @@ export function createWaterfallSvg(data: WaterfallData, options: ChartRenderOpti
   const widestRequestNumber = getWidestDigitString(entriesToShow.length);
   const maxNumberWidth = svg.getNodeTextWidth(svg.newTextEl(`${widestRequestNumber}`), true);
 
-  let barEls: SVGGElement[] = [];
+  let rowItems: SVGAElement[] = [];
 
   function getChartHeight(): number {
     return chartHolderHeight + context.overlayManager.getCombinedOverlayHeight();
@@ -169,12 +169,12 @@ export function createWaterfallSvg(data: WaterfallData, options: ChartRenderOpti
     } as RectData;
 
     let showDetailsOverlay = () => {
-      context.overlayManager.toggleOverlay(i, y + options.rowHeight, detailsHeight, entry, barEls);
+      context.overlayManager.toggleOverlay(i, y + options.rowHeight, detailsHeight, entry, rowItems);
     };
 
     let rowItem = row.createRow(context, i, maxIconsWidth, maxNumberWidth, rectData, entry, showDetailsOverlay);
 
-    barEls.push(rowItem);
+    rowItems.push(rowItem);
     rowHolder.appendChild(rowItem);
     rowHolder.appendChild(svg.newG("row-overlay-holder"));
   }


### PR DESCRIPTION
Now it's possible to go through the entire chart via keyboard (tab/tab+shift to move around; Enter or space to open an overlay).
This required some restructuring of the SVG structure. Overlays are now next to their associated row, instead of all together in a separate holder.

I also fixed the rendering of the tooltips and improved the startup performance a bit (by about 20% on my MBP in Chrome for our standard dev charts ~250ms -> ~200ms).