### PR TITLE
#204 add note to Connect time with TLS

### DIFF
--- a/src/ts/transformers/extract-details-keys.ts
+++ b/src/ts/transformers/extract-details-keys.ts
@@ -146,11 +146,16 @@ function parseTimings(entry: Entry, start: number, end: number): KvTuple[] {
   const optionalTiming = (timing?: number) => parseAndFormat(timing, parseNonNegative, formatMilliseconds);
   const total = (typeof start !== "number" || typeof end !== "number") ? undefined : (end - start);
 
+  let connectVal = optionalTiming(timings.connect);
+  if (timings.ssl > 0) {
+    // SSL time is also included in the connect field (to ensure backward compatibility with HAR 1.1).
+    connectVal = `${connectVal} (without TLS: ${optionalTiming(timings.connect - timings.ssl)})`;
+  }
   return [
     ["Total", formatMilliseconds(total)],
     ["Blocked", optionalTiming(timings.blocked)],
     ["DNS", optionalTiming(timings.dns)],
-    ["Connect", optionalTiming(timings.connect)],
+    ["Connect", connectVal],
     ["SSL (TLS)", optionalTiming(timings.ssl)],
     ["Send", formatMilliseconds(timings.send)],
     ["Wait", formatMilliseconds(timings.wait)],


### PR DESCRIPTION
Optional note that `connect` contains `ssl`
<img width="591" alt="screen shot 2017-05-19 at 7 50 49 am" src="https://cloud.githubusercontent.com/assets/1680390/26226627/1d553ed0-3c68-11e7-94c4-f877c8f2ab9a.png">
