### PR TITLE
Set row max time from outside of PerfCascade

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "live-server": "^1.2.0",
     "load-grunt-config": "^0.19.2",
     "tsify": "^3.0.1",
-    "tslint": "^5.4.3",
+    "tslint": "~5.4.3",
     "tslint-eslint-rules": "^4.1.1",
     "typescript": "^2.3.4",
     "whatwg-fetch": "^2.0.3"

--- a/src/ts/transformers/har.ts
+++ b/src/ts/transformers/har.ts
@@ -7,7 +7,7 @@ import {
 } from "har-format";
 import { roundNumber } from "../helpers/misc";
 import { escapeHtml, toInt } from "../helpers/parse";
-import { HarTransformerOptions } from "../typing/options";
+import { ChartOptions, HarTransformerOptions } from "../typing/options";
 import {
   Mark,
   TimingType,
@@ -89,12 +89,12 @@ const getPages = (data: Log) => {
  * Transforms a HAR object into the format needed to render the PerfCascade
  * @param  {Har} harData - HAR document
  * @param {number=0} pageIndex - page to parse (for multi-page HAR)
- * @param {HarTransformerOptions} options - HAR-parser-specific options
+ * @param {ChartOptions} options - HAR-parser-specific options
  * @returns WaterfallData
  */
 export function transformPage(harData: Har | Log,
                               pageIndex: number = 0,
-                              options: HarTransformerOptions): WaterfallData {
+                              options: ChartOptions): WaterfallData {
   // make sure it's the *.log base node
   const data = (harData["log"] !== undefined ? harData["log"] : harData) as Log;
 
@@ -130,6 +130,11 @@ export function transformPage(harData: Har | Log,
     }
   });
 
+  // if we configured the max time from the outside, use that!
+  if (options.rowMaxTimeInMs) {
+    doneTime = options.rowMaxTimeInMs;
+  }
+
   // Add 100ms margin to make room for labels
   doneTime += 100;
 
@@ -146,9 +151,9 @@ export function transformPage(harData: Har | Log,
  * Extract all `Mark`s based on `PageTiming` and `UserTiming`
  * @param {PageTiming} pageTimings - HARs `PageTiming` object
  * @param {Page} currPage - active page
- * @param {HarTransformerOptions} options - HAR-parser-specific options
+ * @param {ChartOptions} options - HAR options
  */
-const getMarks = (pageTimings: PageTiming, currPage: Page, options: HarTransformerOptions) => {
+const getMarks = (pageTimings: PageTiming, currPage: Page, options: ChartOptions) => {
   const sortFn = (a: Mark, b: Mark) => a.startTime - b.startTime;
   const marks = Object.keys(pageTimings)
     .filter((k: keyof PageTiming) => (typeof pageTimings[k] === "number" && pageTimings[k] >= 0))
@@ -169,9 +174,9 @@ const getMarks = (pageTimings: PageTiming, currPage: Page, options: HarTransform
 /**
  * Extract all `Mark`s based on `UserTiming`
  * @param {Page} currPage - active page
- * @param {HarTransformerOptions} options - HAR-parser-specific options
+ * @param {ChartOptions} options - HAR options
  */
-const getUserTimimngs = (currPage: Page, options: HarTransformerOptions) => {
+const getUserTimimngs = (currPage: Page, options: ChartOptions) => {
   const baseFilter = options.showUserTimingEndMarker ?
     (k: string) => k.indexOf("_userTime.") === 0 :
     (k: string) => k.indexOf("_userTime.") === 0 && k.indexOf("_userTime.endTimer-") !== 0;

--- a/src/ts/transformers/har.ts
+++ b/src/ts/transformers/har.ts
@@ -130,9 +130,9 @@ export function transformPage(harData: Har | Log,
     }
   });
 
-  // if we configured the max time from the outside, use that!
-  if (options.rowMaxTimeInMs) {
-    doneTime = options.rowMaxTimeInMs;
+  // if we configured fixed length from the outside, use that!
+  if (options.fixedLengthMs) {
+    doneTime = options.fixedLengthMs;
   }
 
   // Add 100ms margin to make room for labels

--- a/src/ts/typing/options.ts
+++ b/src/ts/typing/options.ts
@@ -19,8 +19,8 @@ export interface ChartRenderOption {
   legendHolder: HTMLElement;
   /** Callback called when the HAR doc has been parsed into PerfCascases */
   onParsed: (data: WaterfallDocs) => void;
-  /** Set a row max time in ms (if not set the time is calculated from the HAR)  */
-  rowMaxTimeInMs: number;
+  /** Set a row length time in ms (if not set the time is calculated from the HAR)  */
+  fixedLengthMs: number;
 }
 
 export interface HarTransformerOptions {

--- a/src/ts/typing/options.ts
+++ b/src/ts/typing/options.ts
@@ -19,6 +19,8 @@ export interface ChartRenderOption {
   legendHolder: HTMLElement;
   /** Callback called when the HAR doc has been parsed into PerfCascases */
   onParsed: (data: WaterfallDocs) => void;
+  /** Set a row max time in ms (if not set the time is calculated from the HAR)  */
+  rowMaxTimeInMs: number;
 }
 
 export interface HarTransformerOptions {


### PR DESCRIPTION
The use case for this is when you wanna put to waterfall charts on top on each other and you wanna make sure they have the same time line, so it is easier to compare them.