### PR TITLE
Only allow console.warn in a few selected places.

### DIFF
--- a/src/ts/helpers/dom.ts
+++ b/src/ts/helpers/dom.ts
@@ -83,6 +83,7 @@ export function safeSetStyle(el: HTMLElement | SVGElement, property: string, val
   if (property in el.style) {
     el.style[property] = value;
   } else {
+// tslint:disable-next-line:no-console
     console.warn(new Error(`Trying to set non-existing style ` +
       `${property} = ${value} on a <${el.tagName.toLowerCase()}>.`));
   }
@@ -91,6 +92,7 @@ export function safeSetStyle(el: HTMLElement | SVGElement, property: string, val
 /** Sets an attribute, but only if `name` exists on `el` */
 export function safeSetAttribute(el: HTMLElement | SVGElement, name: string, value: string) {
   if (!(name in el)) {
+// tslint:disable-next-line:no-console
     console.warn(new Error(`Trying to set non-existing attribute ` +
       `${name} = ${value} on a <${el.tagName.toLowerCase()}>.`));
   }

--- a/src/ts/helpers/parse.ts
+++ b/src/ts/helpers/parse.ts
@@ -151,6 +151,7 @@ export function sanitizeUrlForLink(unsafeUrl: string) {
   if (cleaned.indexOf("http://") === 0 || cleaned.indexOf("https://") === 0) {
     return cleaned;
   }
+// tslint:disable-next-line:no-console
   console.warn("skipped link, due to potentially unsafe url", unsafeUrl);
   return "";
 }

--- a/tslint.json
+++ b/tslint.json
@@ -7,7 +7,6 @@
     "interface-name": [false],
     "object-curly-spacing": [true],
 
-    "no-console": [false],
     "no-string-literal": false,
 
     // allow-leading-underscore since _ is used to silence warnings about unused function parameters.


### PR DESCRIPTION
Further tweak tslint settings so that console logging needs to be
explicitly allowed in each case. This brings us mote in line with
recommended tslint config.