### PR TITLE
Make it wider on larger screens

### DIFF
--- a/src/css-raw/gh-page.css
+++ b/src/css-raw/gh-page.css
@@ -190,7 +190,6 @@ a:hover {
   }
 }
 
-
 /*.main-content :first-child {
   margin-top: 0;
 }*/
@@ -212,7 +211,8 @@ a:hover {
   margin-bottom: 1rem;
 }
 
-.main-content ul, .main-content ol {
+.main-content ul,
+.main-content ol {
   margin-top: 0;
 }
 
@@ -223,11 +223,11 @@ a:hover {
   border-left: 0.3rem solid #dce6f0;
 }
 
-.main-content blockquote >:first-child {
+.main-content blockquote > :first-child {
   margin-top: 0;
 }
 
-.main-content blockquote >:last-child {
+.main-content blockquote > :last-child {
   margin-bottom: 0;
 }
 
@@ -241,7 +241,7 @@ a:hover {
 
 @media screen and (min-width: 64em) {
   .main-content {
-    max-width: 64rem;
+    max-width: 160rem;
     padding: 2rem 6rem;
     margin: 0 auto;
     font-size: 1.1rem;


### PR DESCRIPTION
One thing that would make the example Github better is that the waterfall is wider on larger screens. Maybe do it in another way, that's perfectly fine + think about the size of the name field.

One other request I have is to remove GA from that page. I know it's nice to have stats, is there a way to get that from Github instead? I don't like that we help them track the people who uses PerfCascade.
