### PR TITLE
Fix missing General tab for rows with warnings.

### DIFF
--- a/src/ts/transformers/har-tabs.ts
+++ b/src/ts/transformers/har-tabs.ts
@@ -92,7 +92,7 @@ function makeGeneralTab(generalData: KvTuple[], indicators: WaterfallEntryIndica
     <dl>${makeDefinitionList(info)}</dl>`;
   }
 
-  makeWaterfallEntryTab("General", content + general);
+  return makeWaterfallEntryTab("General", content + general);
 }
 
 function makeRequestTab(request: KvTuple[], requestHeaders: KvTuple[]): WaterfallEntryTab {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "sourceMap": true,
     "removeComments": false,
     "noImplicitAny": false,
+    "noImplicitReturns": true,
     "noUnusedParameters": true,
     "noUnusedLocals": true
   },


### PR DESCRIPTION
If a har entry had warnings (e.g. missing compression) the General tab for that resource was not shown. Fix issue (a missing return) and configure TypeScript compiler to not allow missing returns by adding the ”noImplicitReturns” option.