### PR TITLE
Add the initiator type (where available)

### DIFF
--- a/src/ts/transformers/extract-details-keys.ts
+++ b/src/ts/transformers/extract-details-keys.ts
@@ -40,6 +40,7 @@ function parseGeneralDetails(entry: Entry, startRelative: number, requestID: num
     ["Was pushed", parseAndFormat(entry._was_pushed, parsePositive, () => "yes")],
     ["Initiator (Loaded by)", entry._initiator],
     ["Initiator Line", entry._initiator_line],
+    ["Initiator Type", entry._initiator_type],
     ["Host", getHeader(entry.request.headers, "Host")],
     ["IP", entry._ip_addr],
     ["Client Port", parseAndFormat(entry._client_port, parsePositive)],


### PR DESCRIPTION
See https://github.com/micmro/PerfCascade/issues/225

![type](https://user-images.githubusercontent.com/540757/38166338-af29b026-3522-11e8-9101-67bc83eb2740.png)
