### PR TITLE
Don’t warn about no https for initial redirect.

### DIFF
--- a/src/ts/transformers/har-heuristics.ts
+++ b/src/ts/transformers/har-heuristics.ts
@@ -62,6 +62,10 @@ function isSecure(entry: Entry) {
   return entry.request.url.indexOf("https://") === 0;
 }
 
+function isInitialRedirect(entry: Entry, index: number) {
+  return index === 0 && !!entry.response.redirectURL;
+}
+
 function isPush(entry: Entry): boolean {
   if (entry._was_pushed === undefined || entry._was_pushed === null) {
     return false;
@@ -84,7 +88,7 @@ export function documentIsSecure(data: Entry[]) {
 }
 
 /** Scans `entry` for noteworthy issues or infos and highlights them */
-export function collectIndicators(entry: Entry, docIsTLS: boolean, requestType: RequestType) {
+export function collectIndicators(entry: Entry, index: number, docIsTLS: boolean, requestType: RequestType) {
   // const harEntry = entry;
   const output: WaterfallEntryIndicator[] = [];
 
@@ -99,7 +103,7 @@ export function collectIndicators(entry: Entry, docIsTLS: boolean, requestType: 
     });
   }
 
-  if (docIsTLS && !isSecure(entry)) {
+  if (docIsTLS && !(isSecure(entry) || isInitialRedirect(entry, index))) {
     output.push({
       description: "Insecure request, it should use HTTPS.",
       displayType: "icon",

--- a/src/ts/transformers/har.ts
+++ b/src/ts/transformers/har.ts
@@ -56,7 +56,7 @@ function toWaterFallEntry(entry: Entry, index: number, startRelative: number, is
   startRelative = Math.round(startRelative);
   const endRelative = Math.round(toInt(entry._all_end) || (startRelative + entry.time));
   const requestType = mimeToRequestType(entry.response.content.mimeType);
-  const indicators = collectIndicators(entry, isTLS, requestType);
+  const indicators = collectIndicators(entry, index, isTLS, requestType);
   const responseDetails = createResponseDetails(entry, indicators);
   return createWaterfallEntry(entry.request.url,
     startRelative,


### PR DESCRIPTION
Avoid flagging an initial http request as insecure if it ends up redirecting to https. A proper http->https redirect setup is a feature, not a bug!