### PR TITLE
Adapt module for ES6

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "perf-cascade",
   "version": "2.6.2",
   "description": "Har file visualizer",
-  "main": "./index.js",
+  "main": "./dist/perf-cascade.js",
+  "module": "./index.js"
   "style": "./dist/perf-cascade.css",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.6.2",
   "description": "Har file visualizer",
   "main": "./dist/perf-cascade.js",
-  "module": "./index.js"
+  "module": "./index.js",
   "style": "./dist/perf-cascade.css",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Following this discussion https://github.com/micmro/PerfCascade/issues/3, we use this module and would like to be able to use it with a SSR react application. 

This change would be a first step in this direction as the current setup fails when we try to import the module in node. As you can see here https://stackoverflow.com/questions/42708484/what-is-the-module-package-json-field-for this would allow node to use the `main` field and ES6-aware tools would use the `module` prop.
