### PR TITLE
feat: add lookahead for marker

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,
+    "alwaysStrict": true,
     "removeComments": false,
     "noImplicitAny": false,
     "noImplicitReturns": true,


### PR DESCRIPTION
closes #272

Added a lookahead for next marker getting pushed beyond 100% and there is no previous marker in the way. Falls back to the existing behaviour.
There are still some edge-cases if there are more markers crowded at the end, but fixing this would be more complex (contribution welcome).

<img width="1678" alt="Screen Shot 2021-03-20 at 10 18 30 PM" src="https://user-images.githubusercontent.com/1680390/111891547-4b9e5980-89ca-11eb-896f-7d4f35e5b446.png">