### PR TITLE
Catch when HAR entry response is missing mime type.

### DIFF
--- a/src/ts/transformers/har-tabs.ts
+++ b/src/ts/transformers/har-tabs.ts
@@ -40,7 +40,7 @@ export function makeTabs(entry: Entry, requestID: number, requestType: RequestTy
   if (requestType === "image") {
     tabs.push(makeImgTab(entry));
   }
-  if (entry.response.content && entry.response.content.mimeType.indexOf("text/") === 0 && entry.response.content.text) {
+  if (entry.response.content && entry.response.content.mimeType && entry.response.content.mimeType.indexOf("text/") === 0 && entry.response.content.text) {
     tabs.push(makeContentTab(entry));
   }
   return tabs.filter((t) => t !== undefined);


### PR DESCRIPTION
Using Firefox with Browsertime I've seen a case at Wikipedia where a entry is missing mime type and that breaks PerfCascade. It's the Covid 19 page and the HAR is 30 mb so not sure where I should put it so you can try @micmro :) I've verified this locally and it fixes the problem.